### PR TITLE
configurable clientOptions for ApolloClient constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ var ENV = {
 }
 ```
 
+Additional configuration of the ApolloClient can be done by extending the Apollo
+service and overriding the `clientOptions` property. See the
+[Apollo Service API][apollo-service-api] for more info.
+
 ## Usage
 
 ### Fetching data
@@ -137,6 +141,19 @@ export default Ember.Route.extend({
 
 The `apollo` service has the following public API:
 
+* `clientOptions`: This computed property should return the options hash that
+  will be passed to the `ApolloClient` [constructor][ac-constructor]. You can
+  override this property to configure the client this service uses:
+  ```js
+  const OverriddenService = ApolloService.extend({
+    clientOptions: computed(function() {
+      let opts = this._super(...arguments);
+      return merge(opts, {
+        dataIdFromObject: customDataIdFromObject
+      };
+    }),
+  });
+  ```
 * `query(options, resultKey)`: This calls the
   [`ApolloClient.watchQuery`](http://dev.apollodata.com/core/apollo-client-api.html#ApolloClient\.watchQuery)
   method. It returns a promise that resolves with an `Ember.Object`. That object
@@ -245,10 +262,12 @@ The tests also contain a sample Star Wars GraphQL schema with an
 
 For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).
 
-[apollo-client]: https://github.com/apollostack/apollo-client
-
 ## Contributors
 
 A special thanks to the following contributors:
 
 * Dan Freeman ([@dfreeman](https://github.com/dfreeman))
+
+[ac-constructor]: http://dev.apollodata.com/core/apollo-client-api.html#ApolloClient\.constructor
+[apollo-client]: https://github.com/apollostack/apollo-client
+[apollo-service-api]: https://github.com/bgentry/ember-apollo-client#apollo-service-api

--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -12,6 +12,7 @@ const {
   merge,
   Object: EmberObject,
   RSVP,
+  run,
   Service,
   setProperties,
   Test,
@@ -137,9 +138,11 @@ export default Service.extend({
             }
             resolve(obj);
           } else {
-            isArray(obj)
-              ? obj.setObjects(dataToSend)
-              : setProperties(obj, dataToSend);
+            run(() => {
+              isArray(obj)
+                ? obj.setObjects(dataToSend)
+                : setProperties(obj, dataToSend);
+            });
           }
         };
         // TODO: add an error function here for handling errors

--- a/tests/acceptance/query-and-unsubscribe-test.js
+++ b/tests/acceptance/query-and-unsubscribe-test.js
@@ -35,23 +35,30 @@ test('visiting /luke', function(assert) {
     assert.equal(currentURL(), '/luke');
     assert.equal(find('.model-name').text(), 'Luke Skywalker');
 
-    // Because we used query() (which uses apollo client's watchQuery) there
-    // should be an ongoing query in the apollo query manager:
-    let queries = getQueries();
-    assert.ok(Object.keys(queries).length, 'there is an active watchQuery');
+    // try updating the mock, refetching the result (w/ queryOnce), and ensuring
+    // that there are no errors:
+    mockHuman.name = 'Luke Skywalker II';
+    click('.refetch-button');
 
-    visit('/');
-
-    andThen(function() {
-      // Now that we've gone to a route with no queries, the
-      // UnsubscribeRouteMixin should have unsubscribed from the watcyQuery andThen
-      // there should be no ongoing queries:
+    andThen(() => {
+      // Because we used query() (which uses apollo client's watchQuery) there
+      // should be an ongoing query in the apollo query manager:
       let queries = getQueries();
-      assert.notOk(
-        Object.keys(queries).length,
-        'there are no active watchQueries'
-      );
-      done();
+      assert.ok(Object.keys(queries).length, 'there is an active watchQuery');
+
+      visit('/');
+
+      andThen(function() {
+        // Now that we've gone to a route with no queries, the
+        // UnsubscribeRouteMixin should have unsubscribed from the watcyQuery andThen
+        // there should be no ongoing queries:
+        let queries = getQueries();
+        assert.notOk(
+          Object.keys(queries).length,
+          'there are no active watchQueries'
+        );
+        done();
+      });
     });
   });
 });

--- a/tests/acceptance/query-and-unsubscribe-test.js
+++ b/tests/acceptance/query-and-unsubscribe-test.js
@@ -7,7 +7,7 @@ let application;
 moduleForAcceptance('Acceptance | main', {
   beforeEach() {
     application = this.application;
-  }
+  },
 });
 
 test('visiting /luke', function(assert) {
@@ -15,15 +15,15 @@ test('visiting /luke', function(assert) {
 
   let mockHuman = {
     id: '1000',
-    name: 'Luke Skywalker'
+    name: 'Luke Skywalker',
   };
   addResolveFunctionsToSchema(this.pretender.schema, {
     Query: {
       human(obj, args) {
         assert.deepEqual(args, { id: '1000' });
         return mockHuman;
-      }
-    }
+      },
+    },
   });
 
   let apollo = application.__container__.lookup('service:apollo');
@@ -47,7 +47,10 @@ test('visiting /luke', function(assert) {
       // UnsubscribeRouteMixin should have unsubscribed from the watcyQuery andThen
       // there should be no ongoing queries:
       let queries = getQueries();
-      assert.notOk(Object.keys(queries).length, 'there are no active watchQueries');
+      assert.notOk(
+        Object.keys(queries).length,
+        'there are no active watchQueries'
+      );
       done();
     });
   });

--- a/tests/dummy/app/routes/luke.js
+++ b/tests/dummy/app/routes/luke.js
@@ -2,9 +2,7 @@ import Ember from 'ember';
 import UnsubscribeRoute from 'ember-apollo-client/mixins/unsubscribe-route';
 import gql from 'graphql-tag';
 
-const {
-  inject: { service }
-} = Ember;
+const { inject: { service } } = Ember;
 
 export default Ember.Route.extend(UnsubscribeRoute, {
   apollo: service(),
@@ -18,5 +16,5 @@ export default Ember.Route.extend(UnsubscribeRoute, {
     `;
     let variables = { id: '1000' };
     return this.get('apollo').query({ query, variables }, 'human');
-  }
+  },
 });

--- a/tests/dummy/app/routes/luke.js
+++ b/tests/dummy/app/routes/luke.js
@@ -4,17 +4,29 @@ import gql from 'graphql-tag';
 
 const { inject: { service } } = Ember;
 
+const query = gql`
+  query human($id: ID!) {
+    human(id: $id) {
+      name
+    }
+  }
+`;
+
+const variables = { id: '1000' };
+
 export default Ember.Route.extend(UnsubscribeRoute, {
   apollo: service(),
   model() {
-    let query = gql`
-      query human($id: ID!) {
-        human(id: $id) {
-          name
-        }
-      }
-    `;
-    let variables = { id: '1000' };
     return this.get('apollo').query({ query, variables }, 'human');
+  },
+
+  actions: {
+    refetchModel() {
+      this.get('apollo').queryOnce({
+        query,
+        variables,
+        fetchPolicy: 'network-only',
+      });
+    },
   },
 });

--- a/tests/dummy/app/templates/luke.hbs
+++ b/tests/dummy/app/templates/luke.hbs
@@ -1,1 +1,3 @@
 <div class='model-name'>{{model.name}}</div>
+
+<button {{action 'refetchModel'}} class='refetch-button'>Refetch</button>

--- a/tests/unit/services/apollo-test.js
+++ b/tests/unit/services/apollo-test.js
@@ -1,16 +1,42 @@
 import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
+import ApolloService from 'ember-apollo-client/services/apollo';
+
+const { computed } = Ember;
 
 let options;
 
 moduleFor('service:apollo', 'Unit | Service | apollo', {
   beforeEach() {
     options = {
-      apiURL: 'https://test.example/graphql'
+      apiURL: 'https://test.example/graphql',
     };
-  }
+  },
 });
 
 test('it exists', function(assert) {
   let service = this.subject({ options });
   assert.ok(service);
+});
+
+test('it uses clientOptions', function(assert) {
+  let customDataIdFromObject = o => o.name;
+  let OverriddenService = ApolloService.extend({
+    // Need this here because apollo requires a uri, but our initializer doesn't
+    // run in unit tests.
+    options: {
+      apiURL: 'https://this-should-be-set-from-environment.example',
+    },
+
+    // Override the clientOptions.
+    clientOptions: computed(function() {
+      let opts = this._super(...arguments);
+      opts.dataIdFromObject = customDataIdFromObject;
+      return opts;
+    }),
+  });
+  let service = OverriddenService.create({});
+
+  // make sure the override was used.
+  assert.equal(service.get('apollo.dataIdFromObject', customDataIdFromObject));
 });


### PR DESCRIPTION
I added a `clientOptions` computed property to the Apollo service. This makes it much easier to override any of [ApolloClient's constructor options](http://dev.apollodata.com/core/apollo-client-api.html#ApolloClient\.constructor) before the client is initialized by the service:

```js
  const OverriddenService = ApolloService.extend({
    clientOptions: computed(function() {
      let opts = this._super(...arguments);
      return merge(opts, {
        dataIdFromObject: customDataIdFromObject
      };
    }),
  });
```

This design followed some discussion on Slack with @viniciussbs. It wasn't appropriate to use simple properties here because there common use cases that require access to the service itself (in the context of `this`), which means this had to be either a function or computed property.

I'm not 100% set on this design and would love to hear from anybody that might have a better one. In the mean time this at least unblocks me :)

Also, this needs docs before being merged.