### PR TITLE
Automatic unsubscribes: new query manager mixins for routes + components

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ export default Ember.Route.extend(UnsubscribeRoute, {
 
   model(params) {
     let variables = { id: params.id };
-    return this.get('apollo').query({ query, variables }, 'human');
+    return this.get('apollo').watchQuery({ query, variables }, 'human');
   }
 });
 ```
@@ -190,7 +190,7 @@ The `apollo` service has the following public API:
     }
   });
   ```
-* `query(options, resultKey)`: This calls the
+* `watchQuery(options, resultKey)`: This calls the
   [`ApolloClient.watchQuery`](http://dev.apollodata.com/core/apollo-client-api.html#ApolloClient\.watchQuery)
   method. It returns a promise that resolves with an `Ember.Object`. That object
   will be updated whenever the `watchQuery` subscription resolves with new data.
@@ -230,7 +230,7 @@ import UnsubscribeRoute from 'ember-apollo-client/mixins/unsubscribe-route';
 
 export default Ember.Route.extend(UnsubscribeRoute, {
   model() {
-    return this.get('apollo').query(...);
+    return this.get('apollo').watchQuery(...);
   }
 });
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This addon includes the following dependencies:
 * [graphql-tag][graphql-tag-repo]
 * [graphql-tools][graphql-tools-repo]
 
-I have been using the non-addon version of this in my own app for a few months.
+I have been using the non-addon version of this in my own app for several months.
 Because I've actually used it to build a real app, I've encountered and solved
 a few real-world problems such as reliable testing and preventing resource leaks
 by unsubscribing from watch queries.
@@ -26,7 +26,7 @@ by unsubscribing from watch queries.
 
 ## Compatibility
 This addon is tested against the `release`, `beta`, and `canary` channels, as
-well as the latest LTS.
+well as the latest two LTS releases.
 
 ## Configuration
 
@@ -50,8 +50,8 @@ service and overriding the `clientOptions` property. See the
 
 ### Fetching data
 
-The addon makes available an `apollo` service. Inject it into your routes and
-you can then use it:
+GraphQL queries should be placed in external files, which are automatically
+made available for import:
 
 `app/gql/queries/human.graphql`
 ```graphql
@@ -62,36 +62,79 @@ query human($id: String!) {
 }
 ```
 
+Though it is not recommended, you can also use the `graphql-tag` package to
+write your queries within your JS file:
+
+```js
+import gql from "graphql-tag";
+
+const query = gql`
+  query human($id: String!) {
+    human(id: $id) {
+      name
+    }
+  }
+`;
+```
+
+Within your routes, you can query for data using the `RouteQueryManager`
+mixin and `watchQuery`:
+
 `app/routes/some-route.js`
 ```js
-import Ember from 'ember';
-import UnsubscribeRoute from 'ember-apollo-client/mixins/unsubscribe-route';
-import query from 'my-app/gql/queries/human';
+import Ember from "ember";
+import RouteQueryManager from "ember-apollo-client/mixins/route-query-manager";
+import query from "my-app/gql/queries/human";
 
-export default Ember.Route.extend(UnsubscribeRoute, {
-  apollo: Ember.inject.service(),
-
+export default Ember.Route.extend(RouteQueryManager, {
   model(params) {
     let variables = { id: params.id };
-    return this.get('apollo').watchQuery({ query, variables }, 'human');
+    return this.apollo.watchQuery({ query, variables }, "human");
   }
 });
 ```
 
-When you use the `query` method, ember-apollo is actually performing a
-`watchQuery` on the ApolloClient. The resulting object is an `Ember.Object` and
-therefore has full support for computed properties, observers, etc.
+This performs a [`watchQuery` on the ApolloClient][watch-query]. The resulting object is an
+`Ember.Object` and therefore has full support for computed properties,
+observers, etc.
 
 If a subsequent query (such as a mutation) happens to fetch the same data while
 this query's subscription is still active, the object will immediately receive
 the latest attributes (just like ember-data).
 
-Please note that when using `query`, you should unsubscribe when you're done
-with the query data. You can instead use `queryOnce` if you just want a single
-query with a POJO response and no watch updates.
+Please note that when using `watchQuery`, you must
+[unsubscribe][unsubscribing] when you're done with the query data. You should
+only have to worry about this if you're using the [Apollo
+service][apollo-service-api] directly. If you use the `RouteQueryManager`
+mixin in your routes, or the `ComponentQueryManager` in your data-loading
+components, all active watch queries are tracked and unsubscribed when the
+route is exited or the component destroyed. These mixins work by injecting a
+query manager named `apollo` that functions as a proxy to the `apollo`
+service.
 
-See the [API docs](#apollo-service-api)
-for more details.
+You can instead use `query` if you just want a single query with a POJO
+response and no watch updates.
+
+If you need to access the Apollo Client [ObservableQuery][observable-query],
+such as for pagination, you can retrieve it from a `watchQuery` result using
+`getObservable`:
+
+```js
+import { getObservable } from "ember-apollo-client";
+
+export default Ember.Route.extend(RouteQueryManager, {
+  model() {
+    let result = this.apollo.query(...);
+    let observable = getObservable(result);
+    observable.fetchMore(...) // utilize the ObservableQuery
+    ...
+  }
+});
+```
+
+See the [detailed query manager docs][query-manager-api] for more details on
+usage, or the [Apollo service API][apollo-service-api] if you need to use
+the service directly.
 
 ### Mutations and Fragments
 
@@ -125,8 +168,8 @@ mutation createReview($ep: Episode!, $review: ReviewInput!) {
 
 `app/routes/my-route.js`
 ```js
-import Ember from 'ember';
-import mutation from 'my-app/gql/mutations/create-review';
+import Ember from "ember";
+import mutation from "my-app/gql/mutations/create-review";
 
 export default Ember.Route.extend({
   apollo: Ember.inject.service(),
@@ -138,13 +181,39 @@ export default Ember.Route.extend({
   actions: {
     createReview(ep, review) {
       let variables = { ep, review };
-      return this.get('apollo').mutate({ mutation, variables }, 'review');
+      return this.get("apollo").mutate({ mutation, variables }, "review");
     }
   }
 });
 ```
 
+### Query manager API
+
+* `watchQuery(options, resultKey)`: This calls the
+  [`ApolloClient.watchQuery`][watch-query] method. It returns a promise that
+  resolves with an `Ember.Object`. That object will be updated whenever the
+  `watchQuery` subscription resolves with new data. As before, the `resultKey`
+  can be used to resolve beneath the root.
+
+  The query manager will automatically unsubscribe from this object.
+* `query(options, resultKey)`: This calls the
+  [`ApolloClient.query`](http://dev.apollodata.com/core/apollo-client-api.html#ApolloClient\.query)
+  method. It returns a promise that resolves with the raw POJO data that the
+  query returns. If you provide a `resultKey`, the resolved data is grabbed from
+  that key in the result.
+* `mutate(options, resultKey)`: This calls the
+  [`ApolloClient.mutate`](http://dev.apollodata.com/core/apollo-client-api.html#ApolloClient\.mutate)
+  method. It returns a promise that resolves with the raw POJO data that the
+  mutation returns. As with the query methods, the `resultKey` can be used to
+  resolve beneath the root.
+
 ### Apollo service API
+
+You should not need to use the Apollo service directly for most regular
+usage, instead utilizing the `RouteQueryManager` and `ComponentQueryManager`
+mixins. However, you will probably need to customize options on the `apollo`
+service, and might need to query it directly for some use cases (such as
+loading data from a service rather than a route or component).
 
 The `apollo` service has the following public API:
 
@@ -163,10 +232,10 @@ The `apollo` service has the following public API:
   ```
 * `middlewares`: This computed property provides a list of [middlewares](http://dev.apollodata.com/core/network.html#networkInterfaceMiddleware) to the network interface. You can use the macro `middlewares` to create your middlewares:
   ```js
-  import middlewares from 'ember-apollo-client/utils/middlewares';
+  import middlewares from "ember-apollo-client/utils/middlewares";
 
   const OverriddenService = ApolloService.extend({
-    middlewares: middlewares('authorize'),
+    middlewares: middlewares("authorize"),
 
     authorize(req, next) {
       // Authorization logic
@@ -191,14 +260,13 @@ The `apollo` service has the following public API:
   });
   ```
 * `watchQuery(options, resultKey)`: This calls the
-  [`ApolloClient.watchQuery`](http://dev.apollodata.com/core/apollo-client-api.html#ApolloClient\.watchQuery)
-  method. It returns a promise that resolves with an `Ember.Object`. That object
-  will be updated whenever the `watchQuery` subscription resolves with new data.
-  As before, the `resultKey` can be used to resolve beneath the root.
+  [`ApolloClient.watchQuery`][watch-query] method. It returns a promise that
+  resolves with an `Ember.Object`. That object will be updated whenever the
+  `watchQuery` subscription resolves with new data. As before, the
+  `resultKey` can be used to resolve beneath the root.
 
-  When using this method, **it is important to
-  [unsubscribe](#unsubscribing-from-watch-queries)** from the query when you're
-  done with it.
+  When using this method, **it is important to [unsubscribe][unsubscribing]**
+  from the query when you're done with it.
 * `queryOnce(options, resultKey)`: This calls the
   [`ApolloClient.query`](http://dev.apollodata.com/core/apollo-client-api.html#ApolloClient\.query)
   method. It returns a promise that resolves with the raw POJO data that the
@@ -212,49 +280,42 @@ The `apollo` service has the following public API:
 
 ### Unsubscribing from watch queries
 
-Apollo client's watchQuery will continue to update the query with new data
+Apollo Client's `watchQuery` will continue to update the query with new data
 whenever the store is updated with new data about the resolved objects. This
 happens until you explicitly unsubscribe from it.
 
-In ember-apollo-client, this is exposed on the result of `query` via a method
-`_apolloUnsubscribe`. You should call this method whenever you're done with the
-query. On a route, this can be done with the `resetController` hook. In a
-component, this cleanup is typically done with a `willDestroyElement` hook.
+In ember-apollo-client, most unsubscriptions are handled automatically by the
+`RouteQueryManager` and `ComponentQueryManager` mixins, so long as you use
+them.
 
-To make this easier on routes, this addon also provides a mixin called
-`UnsubscribeRoute`. You can use it in your route like this:
+If you're fetching data elsewhere, such as in an Ember Service, or if you use
+the Apollo service directly, you are responsible for unsubscribing from
+`watchQuery` results when you're done with them. This is exposed on the
+result of `query` via a method `_apolloUnsubscribe`.
 
+### Injecting the `RouteQueryManager` mixin into all routes
+
+ember-apollo-client does not automatically inject any dependencies into your
+routes. If you want to inject this mixin into all routes, you should utilize
+a base route class:
+
+`app/routes/base.js`
 ```js
-import Ember from 'ember';
-import UnsubscribeRoute from 'ember-apollo-client/mixins/unsubscribe-route';
+import Ember from "ember";
+import RouteQueryManager from "ember-apollo-client/mixins/route-query-manager";
 
-export default Ember.Route.extend(UnsubscribeRoute, {
-  model() {
-    return this.get('apollo').watchQuery(...);
-  }
-});
+export default Ember.Route.extend(RouteQueryManager);
 ```
 
-The mixin will call `_apolloUnsubscribe` on the `model` (if it is set) when the
-model changes or the route deactivates. For now, this only works if your model
-was resolved directly from the apollo service. It does not work if your `model`
-hook returns an `RSVP.hash` of multiple queries, or something of that sort.
-You'd have to clean up manually in that scenario.
+Then extend from that in your other routes:
 
-### Injecting the apollo service into all routes
-
-The apollo service is not automatically injected into your routes, but you can
-do so easily with an initializer like this one:
-
+`app/routes/a-real-route.js`
 ```js
-export function initialize(application) {
-  application.inject('route', 'apollo', 'service:apollo');
-}
+import Base from "my-app/routes/base";
 
-export default {
-  name: 'apollo',
-  initialize
-};
+export default Base.extend(
+  ...
+)
 ```
 
 ### Testing
@@ -307,4 +368,8 @@ A special thanks to the following contributors:
 
 [ac-constructor]: http://dev.apollodata.com/core/apollo-client-api.html#ApolloClient\.constructor
 [apollo-client]: https://github.com/apollostack/apollo-client
-[apollo-service-api]: https://github.com/bgentry/ember-apollo-client#apollo-service-api
+[apollo-service-api]: #apollo-service-api
+[observable-query]: http://dev.apollodata.com/core/apollo-client-api.html#ObservableQuery
+[query-manager-api]: #query-manager-api
+[unsubscribing]: #unsubscribing-from-watch-queries
+[watch-query]: http://dev.apollodata.com/core/apollo-client-api.html#ApolloClient\.watchQuery

--- a/addon/apollo/query-manager.js
+++ b/addon/apollo/query-manager.js
@@ -12,14 +12,48 @@ export default EmberObject.extend({
     this.set('activeSubscriptions', A([]));
   },
 
+  /**
+   * Executes a mutation on the Apollo service. The resolved object will
+   * never be updated and does not have to be unsubscribed.
+   *
+   * @method mutate
+   * @param {!Object} opts The query options used in the Apollo Client mutate.
+   * @param {String} resultKey The key that will be returned from the resulting response data. If null or undefined, the entire response data will be returned.
+   * @return {!Promise}
+   * @public
+   */
   mutate(opts) {
     return this.get('apollo').mutate(opts);
   },
 
+  /**
+   * Executes a single `query` on the Apollo service. The resolved object will
+   * never be updated and does not have to be unsubscribed.
+   *
+   * @method queryOnce
+   * @param {!Object} opts The query options used in the Apollo Client query.
+   * @param {String} resultKey The key that will be returned from the resulting response data. If null or undefined, the entire response data will be returned.
+   * @return {!Promise}
+   * @public
+   */
   query(opts, resultKey) {
     return this.get('apollo').queryOnce(opts, resultKey);
   },
 
+  /**
+   * Executes a `watchQuery` on the Apollo service. If updated data for this
+   * query is loaded into the store by another query, the resolved object will
+   * be updated with the new data.
+   *
+   * This watch query is tracked by the QueryManager and will be unsubscribed
+   * (and no longer updated with new data) when unsubscribeAll() is called.
+   *
+   * @method watchQuery
+   * @param {!Object} opts The query options used in the Apollo Client watchQuery.
+   * @param {String} resultKey The key that will be returned from the resulting response data. If null or undefined, the entire response data will be returned.
+   * @return {!Promise}
+   * @public
+   */
   watchQuery(opts, resultKey) {
     return this.get('apollo').managedWatchQuery(this, opts, resultKey);
   },
@@ -36,6 +70,16 @@ export default EmberObject.extend({
     this.get('activeSubscriptions').pushObject(subscription);
   },
 
+  /**
+   * Unsubscribes from all actively tracked subscriptions initiated by calls to
+   * `watchQuery`. This is normally called automatically by the
+   * ComponentQueryManagerMixin when a component is torn down, or by the
+   * RouteQueryManagerMixin when `resetController` is called on the route.
+   *
+   * @method unsubscribeAll
+   * @return {!Promise}
+   * @public
+   */
   unsubscribeAll() {
     let subscriptions = this.get('activeSubscriptions');
     subscriptions.forEach(subscription => {

--- a/addon/apollo/query-manager.js
+++ b/addon/apollo/query-manager.js
@@ -1,0 +1,46 @@
+import Ember from 'ember';
+
+const { A, inject: { service }, Object: EmberObject } = Ember;
+
+export default EmberObject.extend({
+  apollo: service(),
+
+  activeSubscriptions: null,
+
+  init() {
+    this._super(...arguments);
+    this.set('activeSubscriptions', A([]));
+  },
+
+  mutate(opts) {
+    return this.get('apollo').mutate(opts);
+  },
+
+  query(opts, resultKey) {
+    return this.get('apollo').queryOnce(opts, resultKey);
+  },
+
+  watchQuery(opts, resultKey) {
+    return this.get('apollo').managedWatchQuery(this, opts, resultKey);
+  },
+
+   /**
+   * Tracks a subscription in the list of active subscriptions, which will all be
+   * cancelled when `unsubcribeAll` is called.
+   *
+   * @method trackSubscription
+   * @param {!Object} subscription The Apollo Client Subscription to be tracked for future unsubscription.
+   * @private
+   */
+  trackSubscription(subscription) {
+    this.get('activeSubscriptions').pushObject(subscription);
+  },
+
+  unsubscribeAll() {
+    let subscriptions = this.get('activeSubscriptions');
+    subscriptions.forEach(subscription => {
+      subscription.unsubscribe();
+    });
+    this.set('activeSubscriptions', A([]));
+  },
+});

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,0 +1,5 @@
+export function getObservable(queryResult) {
+  return queryResult._apolloObservable;
+}
+
+export let apolloObservableKey = '_apolloObservable';

--- a/addon/mixins/base-query-manager.js
+++ b/addon/mixins/base-query-manager.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+
+const { inject: { service }, Mixin } = Ember;
+
+export default Mixin.create({
+  apollo: service(),
+
+  init() {
+    this._super(...arguments);
+
+    let queryManager = this.get('apollo').createQueryManager();
+    this.set('apollo', queryManager);
+  },
+});

--- a/addon/mixins/component-query-manager.js
+++ b/addon/mixins/component-query-manager.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+import BaseQueryManager from 'ember-apollo-client/mixins/base-query-manager';
+
+const { Mixin } = Ember;
+
+export default Mixin.create(BaseQueryManager, {
+  willDestroyElement() {
+    this._super(...arguments);
+    this.get('apollo').unsubscribeAll();
+  },
+});

--- a/addon/mixins/component-query-manager.js
+++ b/addon/mixins/component-query-manager.js
@@ -6,6 +6,6 @@ const { Mixin } = Ember;
 export default Mixin.create(BaseQueryManager, {
   willDestroyElement() {
     this._super(...arguments);
-    this.get('apollo').unsubscribeAll();
+    this.get('apollo').unsubscribeAll(false);
   },
 });

--- a/addon/mixins/route-query-manager.js
+++ b/addon/mixins/route-query-manager.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+import BaseQueryManager from 'ember-apollo-client/mixins/base-query-manager';
+
+const { Mixin } = Ember;
+
+export default Mixin.create(BaseQueryManager, {
+  resetController() {
+    this._super(...arguments);
+    this.get('apollo').unsubscribeAll();
+  },
+});

--- a/addon/mixins/route-query-manager.js
+++ b/addon/mixins/route-query-manager.js
@@ -4,8 +4,13 @@ import BaseQueryManager from 'ember-apollo-client/mixins/base-query-manager';
 const { Mixin } = Ember;
 
 export default Mixin.create(BaseQueryManager, {
-  resetController() {
+  beforeModel() {
+    this.get('apollo').markSubscriptionsStale();
+    return this._super(...arguments);
+  },
+
+  resetController(_controller, isExiting) {
     this._super(...arguments);
-    this.get('apollo').unsubscribeAll();
+    this.get('apollo').unsubscribeAll(!isExiting);
   },
 });

--- a/addon/mixins/unsubscribe-route.js
+++ b/addon/mixins/unsubscribe-route.js
@@ -1,9 +1,14 @@
 import Ember from 'ember';
 
-const { Mixin } = Ember;
+const { deprecate, Mixin } = Ember;
 
 export default Mixin.create({
   resetController() {
+    deprecate(`The \`UnsubscribeRoute\` mixin is deprecated, use \`RouteQueryManager\` instead.`, false, {
+      id: 'ember-apollo-client.deprecate-unsubscribe-route',
+      until: '1.0.0',
+    });
+
     this._super(...arguments);
 
     // If the model came from an apollo query, it will have an

--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -98,7 +98,7 @@ export default Service.extend({
    * Executes a mutation on the Apollo client. The resolved object will
    * never be updated and does not have to be unsubscribed.
    *
-   * @method query
+   * @method mutate
    * @param {!Object} opts The query options used in the Apollo Client mutate.
    * @param {String} resultKey The key that will be returned from the resulting response data. If null or undefined, the entire response data will be returned.
    * @return {!Promise}

--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -6,6 +6,7 @@ const {
   A,
   copy,
   computed,
+  deprecate,
   isArray,
   isNone,
   isPresent,
@@ -144,10 +145,34 @@ export default Service.extend({
    * @method query
    * @param {!Object} opts The query options used in the Apollo Client watchQuery.
    * @param {String} resultKey The key that will be returned from the resulting response data. If null or undefined, the entire response data will be returned.
+   * @deprecated Use `watchQuery` instead.
    * @return {!Promise}
    * @public
    */
   query(opts, resultKey) {
+    deprecate(`Usage of \`query\` is deprecated, use \`watchQuery\` instead.`, false, {
+      id: 'ember-apollo-client.deprecate-query-for-watch-query',
+      until: '1.0.0',
+    });
+    return this.watchQuery(opts, resultKey);
+  },
+
+  /**
+   * Executes a `watchQuery` on the Apollo client. If updated data for this
+   * query is loaded into the store by another query, the resolved object will
+   * be updated with the new data.
+   *
+   * When using this method, it is important to call `apolloUnsubscribe()` on
+   * the resolved data when the route or component is torn down. That tells
+   * Apollo to stop trying to send updated data to a non-existent listener.
+   *
+   * @method watchQuery
+   * @param {!Object} opts The query options used in the Apollo Client watchQuery.
+   * @param {String} resultKey The key that will be returned from the resulting response data. If null or undefined, the entire response data will be returned.
+   * @return {!Promise}
+   * @public
+   */
+  watchQuery(opts, resultKey) {
     let obj, subscription;
     let _apolloUnsubscribe = function() {
       subscription.unsubscribe();

--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import ApolloClient, { createNetworkInterface } from 'apollo-client';
+import apolloObservableKey from 'ember-apollo-client';
 import QueryManager from 'ember-apollo-client/apollo/query-manager';
 
 const {
@@ -26,7 +27,8 @@ const { alias } = computed;
 
 function newDataFunc(observable, resultKey, resolve) {
   let obj;
-  let mergedProps = { _apolloObservable: observable };
+  let mergedProps = {};
+  mergedProps[apolloObservableKey] = observable;
 
   return ({ data }) => {
     let dataToSend = isNone(resultKey) ? data : get(data, resultKey);

--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -9,6 +9,7 @@ const {
   isArray,
   isNone,
   isPresent,
+  get,
   getOwner,
   merge,
   Object: EmberObject,
@@ -27,7 +28,7 @@ function newDataFunc(observable, resultKey, resolve) {
   let mergedProps = { _apolloObservable: observable };
 
   return ({ data }) => {
-    let dataToSend = isNone(resultKey) ? data : data[resultKey];
+    let dataToSend = isNone(resultKey) ? data : get(data, resultKey);
     dataToSend = copy(dataToSend, true);
     if (isNone(obj)) {
       if (isArray(dataToSend)) {
@@ -154,7 +155,7 @@ export default Service.extend({
     return this._waitFor(
       new RSVP.Promise((resolve, reject) => {
         let newData = ({ data }) => {
-          let dataToSend = isNone(resultKey) ? data : data[resultKey];
+          let dataToSend = isNone(resultKey) ? data : get(data, resultKey);
           dataToSend = copy(dataToSend, true);
           if (isNone(obj)) {
             if (isArray(dataToSend)) {

--- a/tests/acceptance/query-and-unsubscribe-test.js
+++ b/tests/acceptance/query-and-unsubscribe-test.js
@@ -41,8 +41,8 @@ test('visiting /luke', function(assert) {
     click('.refetch-button');
 
     andThen(() => {
-      // Because we used query() (which uses apollo client's watchQuery) there
-      // should be an ongoing query in the apollo query manager:
+      // Because we used watchQuery() there should be an ongoing query in the
+      // apollo query manager:
       let queries = getQueries();
       assert.ok(Object.keys(queries).length, 'there is an active watchQuery');
 

--- a/tests/acceptance/query-and-unsubscribe-test.js
+++ b/tests/acceptance/query-and-unsubscribe-test.js
@@ -32,7 +32,7 @@ test('visiting /luke', function(assert) {
     Query: {
       human(obj, args) {
         assert.deepEqual(args, { id: '1000' });
-        return human;
+        return copy(human);
       },
     },
   });
@@ -48,16 +48,17 @@ test('visiting /luke', function(assert) {
 
     // try updating the mock, refetching the result (w/ queryOnce), and ensuring
     // that there are no errors:
-    human.name = 'Luke Skywalker II';
+    human.name = 'Lucas Skywalker';
     click('.refetch-button');
 
     andThen(() => {
+      assert.equal(find('.model-name').text(), 'Lucas Skywalker');
       // Because we used watchQuery() there should be an ongoing query in the
       // apollo query manager:
       let queries = getQueries();
       assert.ok(Object.keys(queries).length, 'there is an active watchQuery');
 
-      visit('/');
+      visit('/new-review');
 
       andThen(function() {
         // Now that we've gone to a route with no queries, the

--- a/tests/dummy/app/controllers/characters.js
+++ b/tests/dummy/app/controllers/characters.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  queryParams: ['kind'],
+  kind: null
+});

--- a/tests/dummy/app/gql/queries/characters.graphql
+++ b/tests/dummy/app/gql/queries/characters.graphql
@@ -1,0 +1,12 @@
+query characters($kind: String!) {
+  characters(kind: $kind) {
+    ... on Droid {
+      id
+      name
+    }
+    ... on Human {
+      id
+      name
+    }
+  }
+}

--- a/tests/dummy/app/mixins/component-query-manager.js
+++ b/tests/dummy/app/mixins/component-query-manager.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-apollo-client/mixins/component-query-manager';

--- a/tests/dummy/app/mixins/route-query-manager.js
+++ b/tests/dummy/app/mixins/route-query-manager.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-apollo-client/mixins/route-query-manager';

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -7,6 +7,7 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+  this.route('characters');
   this.route('luke');
   this.route('new-review');
 });

--- a/tests/dummy/app/routes/characters.js
+++ b/tests/dummy/app/routes/characters.js
@@ -1,0 +1,19 @@
+import Ember from 'ember';
+import RouteQueryManager from 'ember-apollo-client/mixins/route-query-manager';
+import query from 'dummy/gql/queries/characters';
+
+const { inject: { service } } = Ember;
+
+export default Ember.Route.extend(RouteQueryManager, {
+  apollo: service(),
+
+  queryParams: {
+    kind: {
+      refreshModel: true
+    }
+  },
+
+  model(variables) {
+    return this.apollo.watchQuery({ query, variables }, 'characters');
+  }
+});

--- a/tests/dummy/app/routes/characters.js
+++ b/tests/dummy/app/routes/characters.js
@@ -2,11 +2,7 @@ import Ember from 'ember';
 import RouteQueryManager from 'ember-apollo-client/mixins/route-query-manager';
 import query from 'dummy/gql/queries/characters';
 
-const { inject: { service } } = Ember;
-
 export default Ember.Route.extend(RouteQueryManager, {
-  apollo: service(),
-
   queryParams: {
     kind: {
       refreshModel: true

--- a/tests/dummy/app/routes/luke.js
+++ b/tests/dummy/app/routes/luke.js
@@ -1,20 +1,20 @@
 import Ember from 'ember';
-import UnsubscribeRoute from 'ember-apollo-client/mixins/unsubscribe-route';
+import RouteQueryManager from 'ember-apollo-client/mixins/route-query-manager';
 import query from 'dummy/gql/queries/human';
 
 const { inject: { service } } = Ember;
 
 const variables = { id: '1000' };
 
-export default Ember.Route.extend(UnsubscribeRoute, {
+export default Ember.Route.extend(RouteQueryManager, {
   apollo: service(),
   model() {
-    return this.get('apollo').query({ query, variables }, 'human');
+    return this.apollo.query({ query, variables }, 'human');
   },
 
   actions: {
     refetchModel() {
-      this.get('apollo').queryOnce({
+      this.apollo.query({
         query,
         variables,
         fetchPolicy: 'network-only',

--- a/tests/dummy/app/routes/luke.js
+++ b/tests/dummy/app/routes/luke.js
@@ -9,7 +9,7 @@ const variables = { id: '1000' };
 export default Ember.Route.extend(RouteQueryManager, {
   apollo: service(),
   model() {
-    return this.apollo.query({ query, variables }, 'human');
+    return this.apollo.watchQuery({ query, variables }, 'human');
   },
 
   actions: {

--- a/tests/dummy/app/routes/luke.js
+++ b/tests/dummy/app/routes/luke.js
@@ -2,12 +2,9 @@ import Ember from 'ember';
 import RouteQueryManager from 'ember-apollo-client/mixins/route-query-manager';
 import query from 'dummy/gql/queries/human';
 
-const { inject: { service } } = Ember;
-
 const variables = { id: '1000' };
 
 export default Ember.Route.extend(RouteQueryManager, {
-  apollo: service(),
   model() {
     return this.apollo.watchQuery({ query, variables }, 'human');
   },

--- a/tests/dummy/app/routes/new-review.js
+++ b/tests/dummy/app/routes/new-review.js
@@ -2,14 +2,11 @@ import Ember from 'ember';
 import mutation from 'dummy/gql/mutations/create-review';
 
 const {
-  inject: { service },
   Object: EmberObject,
   Route
 } = Ember;
 
 export default Route.extend({
-  apollo: service(),
-
   model() {
     return EmberObject.create({});
   },

--- a/tests/dummy/app/services/apollo.js
+++ b/tests/dummy/app/services/apollo.js
@@ -1,0 +1,17 @@
+import ApolloService from "ember-apollo-client/services/apollo";
+import Ember from "ember";
+import { IntrospectionFragmentMatcher } from "apollo-client";
+import TypeIntrospectionQuery from "dummy/utils/graphql-type-query";
+
+const { computed, merge } = Ember;
+
+export default ApolloService.extend({
+  clientOptions: computed(function() {
+    let opts = this._super(...arguments);
+    return merge(opts, {
+      fragmentMatcher: new IntrospectionFragmentMatcher({
+        introspectionQueryResultData: TypeIntrospectionQuery,
+      }),
+    });
+  }),
+});

--- a/tests/dummy/app/templates/characters.hbs
+++ b/tests/dummy/app/templates/characters.hbs
@@ -1,0 +1,5 @@
+<ul>
+  {{#each model as |item|}}
+    <li class='model-name'>{{item.name}}</li>
+  {{/each}}
+</ul>

--- a/tests/dummy/app/utils/graphql-type-query.js
+++ b/tests/dummy/app/utils/graphql-type-query.js
@@ -1,0 +1,76 @@
+export default {
+  __schema: {
+    types: [
+      {
+        kind: "UNION",
+        name: "SearchResult",
+        possibleTypes: [
+          {
+            name: "Droid",
+          },
+          {
+            name: "Human",
+          },
+          {
+            name: "Starship",
+          },
+        ],
+      },
+      {
+        kind: "OBJECT",
+        name: "Droid",
+        possibleTypes: null,
+      },
+      {
+        kind: "OBJECT",
+        name: "Human",
+        possibleTypes: null,
+      },
+      {
+        kind: "OBJECT",
+        name: "Starship",
+        possibleTypes: null,
+      },
+      {
+        kind: "OBJECT",
+        name: "__Schema",
+        possibleTypes: null,
+      },
+      {
+        kind: "OBJECT",
+        name: "__Type",
+        possibleTypes: null,
+      },
+      {
+        kind: "ENUM",
+        name: "__TypeKind",
+        possibleTypes: null,
+      },
+      {
+        kind: "OBJECT",
+        name: "__Field",
+        possibleTypes: null,
+      },
+      {
+        kind: "OBJECT",
+        name: "__InputValue",
+        possibleTypes: null,
+      },
+      {
+        kind: "OBJECT",
+        name: "__EnumValue",
+        possibleTypes: null,
+      },
+      {
+        kind: "OBJECT",
+        name: "__Directive",
+        possibleTypes: null,
+      },
+      {
+        kind: "ENUM",
+        name: "__DirectiveLocation",
+        possibleTypes: null,
+      },
+    ],
+  },
+};

--- a/tests/fixtures/test-schema.graphql.js
+++ b/tests/fixtures/test-schema.graphql.js
@@ -12,6 +12,8 @@ type Query {
 
   search(text: String): [SearchResult]
 
+  characters(kind: String): [SearchResult]
+
   droid(id: ID!): Droid
 
   human(id: ID!): Human

--- a/tests/unit/get-observable-test.js
+++ b/tests/unit/get-observable-test.js
@@ -1,0 +1,15 @@
+import { getObservable } from 'ember-apollo-client';
+import { module, test } from 'qunit';
+import Ember from 'ember';
+
+const { Object: EmberObject } = Ember;
+
+module('Unit | getObservable');
+
+test('it should return the observable from a result object', function(assert) {
+  let mockObservable = { fakeObservable: true }
+  let resultObject = EmberObject.create({ _apolloObservable: mockObservable })
+
+  let result = getObservable(resultObject);
+  assert.deepEqual(result, mockObservable);
+});

--- a/tests/unit/mixins/component-query-manager-test.js
+++ b/tests/unit/mixins/component-query-manager-test.js
@@ -1,0 +1,51 @@
+import Ember from 'ember';
+import ComponentQueryManagerMixin from 'ember-apollo-client/mixins/component-query-manager';
+import { moduleFor, test } from 'ember-qunit';
+
+const { getOwner, Object: EmberObject } = Ember;
+
+moduleFor(
+  'mixin:component-query-manager',
+  'Unit | Mixin | component query manager', {
+    needs: ['service:apollo'],
+    beforeEach() {
+      // needed to set up config since initializers don't run here
+      const options = { apiURL: 'https://test.example/graphql' };
+      this.register('config:apollo', options, { instantiate: false });
+      getOwner(this).inject('service:apollo', 'options', 'config:apollo');
+    },
+    subject() {
+      let TestObject = EmberObject.extend(ComponentQueryManagerMixin);
+      this.register('test-container:test-object', TestObject);
+      return getOwner(this).lookup('test-container:test-object');
+    },
+  }
+);
+
+test('it unsubscribes from any watchQuery subscriptions', function(assert) {
+  let done = assert.async();
+  let subject = this.subject();
+  let unsubscribeCalled = 0;
+
+  let apolloService = subject.get('apollo.apollo');
+  apolloService.set('managedWatchQuery', (manager, opts) => {
+    assert.deepEqual(opts, { query: 'fakeQuery' });
+    manager.get('activeSubscriptions').pushObject({
+      unsubscribe() {
+        unsubscribeCalled++;
+      },
+    });
+    return {};
+  });
+
+  subject.apollo.watchQuery({ query: 'fakeQuery' });
+  subject.apollo.watchQuery({ query: 'fakeQuery' });
+
+  subject.willDestroyElement();
+  assert.equal(
+    unsubscribeCalled,
+    2,
+    '_apolloUnsubscribe() was called once per watchQuery'
+  );
+  done();
+});

--- a/tests/unit/mixins/component-query-manager-test.js
+++ b/tests/unit/mixins/component-query-manager-test.js
@@ -30,7 +30,7 @@ test('it unsubscribes from any watchQuery subscriptions', function(assert) {
   let apolloService = subject.get('apollo.apollo');
   apolloService.set('managedWatchQuery', (manager, opts) => {
     assert.deepEqual(opts, { query: 'fakeQuery' });
-    manager.get('activeSubscriptions').pushObject({
+    manager.trackSubscription({
       unsubscribe() {
         unsubscribeCalled++;
       },

--- a/tests/unit/mixins/route-query-manager-test.js
+++ b/tests/unit/mixins/route-query-manager-test.js
@@ -1,0 +1,52 @@
+import Ember from 'ember';
+import RouteQueryManagerMixin from 'ember-apollo-client/mixins/route-query-manager';
+import { moduleFor, test } from 'ember-qunit';
+
+const { getOwner, Object: EmberObject } = Ember;
+
+moduleFor(
+  'mixin:route-query-manager',
+  'Unit | Mixin | route query manager',
+  {
+    needs: ['service:apollo'],
+    beforeEach() {
+      // needed to set up config since initializers don't run here
+      const options = { apiURL: 'https://test.example/graphql' };
+      this.register('config:apollo', options, { instantiate: false });
+      getOwner(this).inject('service:apollo', 'options', 'config:apollo');
+    },
+    subject() {
+      let TestObject = EmberObject.extend(RouteQueryManagerMixin);
+      this.register('test-container:test-object', TestObject);
+      return getOwner(this).lookup('test-container:test-object');
+    },
+  }
+);
+
+test('it unsubscribes from any watchQuery subscriptions', function(assert) {
+  let done = assert.async();
+  let subject = this.subject();
+  let unsubscribeCalled = 0;
+
+  let apolloService = subject.get('apollo.apollo');
+  apolloService.set('managedWatchQuery', (manager, opts) => {
+    assert.deepEqual(opts, { query: 'fakeQuery' });
+    manager.get('activeSubscriptions').pushObject({
+      unsubscribe() {
+        unsubscribeCalled++;
+      },
+    });
+    return {};
+  });
+
+  subject.apollo.watchQuery({ query: 'fakeQuery' });
+  subject.apollo.watchQuery({ query: 'fakeQuery' });
+
+  subject.resetController();
+  assert.equal(
+    unsubscribeCalled,
+    2,
+    '_apolloUnsubscribe() was called once per watchQuery'
+  );
+  done();
+});


### PR DESCRIPTION
This is an attempt at solving #19.

These mixins are intended to replace most direct usage of the Apollo service. The query managers act as a proxy to the Apollo service, tracking all watched queries made in a route or component and automatically unsubscribing from them via the respective lifecycle hooks.

Additionally, the objects returned by watchQuery include an `_apolloObservable` property that gives direct access to the ObservableQuery returned by ApolloClient.watchQuery. This should make it easy to refetch queries or handle paginated result sets.

This is poorly tested so far! I'm posting it now for feedback. Here's what the proposed usage would be in a route:

```js
import ApolloRouteQueryManager from 'myapp/mixins/apollo-route-query-manager';

export default Ember.Route.extend(ApolloRouteQueryManager, {
  model() {
    return Ember.RSVP.hash({
      episodes: this.apollo.watchQuery({ query: EpisodesQuery }, 'episodes'),
      heroes: this.apollo.watchQuery({ query: HeroesQuery }, 'heroes')
    });
  }
```

The `this.apollo` in the route is not actually the apollo service; it's a proxy object that tracks any queries performed in the route, automatically unsubscribing from them when `resetController` is called.

The usage for components is similar.

cc @viniciussbs