### PR TITLE
Fix dependency caching across rebuilds

### DIFF
--- a/lib/webpack-dependency-plugin.js
+++ b/lib/webpack-dependency-plugin.js
@@ -25,7 +25,7 @@ module.exports = class WebpackDependencyPlugin extends Plugin {
   }
 
   build() {
-    let outputFile = path.join(this.outputPath, '-apollo-bundle.js');
+    let outputFile = path.join(this.outputPath, `-${this.options.outputName}-bundle.js`);
     if (fs.existsSync(outputFile)) return;
 
     this._writeEntryFile();


### PR DESCRIPTION
Prior to this, we were looking at the wrong path to determine whether dependencies needed to be built 😳 

Now `WebpackDependencyPlugin` doesn't even make the list of contributors for rebuilds.

![image](https://cloud.githubusercontent.com/assets/108688/25597957/034d47a6-2ea0-11e7-9f39-de8b29bc8ed5.png)
