### PR TITLE
Add middlewares to `ApolloService`

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,35 @@ The `apollo` service has the following public API:
     }),
   });
   ```
+* `middlewares`: This computed property provides a list of [middlewares](http://dev.apollodata.com/core/network.html#networkInterfaceMiddleware) to the network interface. You can use the macro `middlewares` to create your middlewares:
+  ```js
+  import middlewares from 'ember-apollo-client/utils/middlewares';
+
+  const OverriddenService = ApolloService.extend({
+    middlewares: middlewares('authorize'),
+
+    authorize(req, next) {
+      // Authorization logic
+      next();
+    }
+  });
+  ```
+
+  Or create them on your own:
+  ```js
+  const OverriddenService = ApolloService.extend({
+    middlewares: computed(function() {
+      return [
+        { applyMiddleware: (req, next) => this.authorize(req, next) }
+      ];
+    }),
+
+    authorize(req, next) {
+      // Authorization logic
+      next();
+    }
+  });
+  ```
 * `query(options, resultKey)`: This calls the
   [`ApolloClient.watchQuery`](http://dev.apollodata.com/core/apollo-client-api.html#ApolloClient\.watchQuery)
   method. It returns a promise that resolves with an `Ember.Object`. That object
@@ -267,6 +296,7 @@ For more information on using ember-cli, visit [https://ember-cli.com/](https://
 A special thanks to the following contributors:
 
 * Dan Freeman ([@dfreeman](https://github.com/dfreeman))
+* Vinícius Sales ([@viniciussbs](https://github.com/viniciussbs))
 
 [ac-constructor]: http://dev.apollodata.com/core/apollo-client-api.html#ApolloClient\.constructor
 [apollo-client]: https://github.com/apollostack/apollo-client

--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -54,9 +54,15 @@ export default Service.extend({
    */
   clientOptions: computed(function() {
     const apiURL = this.get('apiURL');
+    const middlewares = this.get('middlewares');
+    const networkInterface = createNetworkInterface({ uri: apiURL });
+
+    if (isPresent(middlewares)) {
+      networkInterface.use(middlewares);
+    }
 
     return {
-      networkInterface: createNetworkInterface({ uri: apiURL }),
+      networkInterface,
       // This dataIdFromObject only works with globally unique IDs. You can
       // override it if your IDs are not already globally unique.
       dataIdFromObject: o => o.id,

--- a/addon/utils/middlewares.js
+++ b/addon/utils/middlewares.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+const { computed } = Ember;
+
+export default function middlewares(...middlewares) {
+  return computed(function() {
+    return middlewares.map((middleware) => {
+      return { applyMiddleware: this.get(middleware).bind(this) };
+    });
+  });
+}

--- a/app/utils/middlewares.js
+++ b/app/utils/middlewares.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-apollo-client/utils/middlewares';

--- a/app/utils/middlewares.js
+++ b/app/utils/middlewares.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-apollo-client/utils/middlewares';

--- a/tests/unit/utils/middlewares-test.js
+++ b/tests/unit/utils/middlewares-test.js
@@ -1,4 +1,4 @@
-import middlewares from 'dummy/utils/middlewares';
+import middlewares from 'ember-apollo-client/utils/middlewares';
 import { module, test } from 'qunit';
 import Ember from 'ember';
 

--- a/tests/unit/utils/middlewares-test.js
+++ b/tests/unit/utils/middlewares-test.js
@@ -1,0 +1,20 @@
+import middlewares from 'dummy/utils/middlewares';
+import { module, test } from 'qunit';
+import Ember from 'ember';
+
+const { Object: EmberObject } = Ember;
+
+module('Unit | Utility | middlewares');
+
+test('it should create a middleware list', function(assert) {
+  let Service = EmberObject.extend({
+    middlewares: middlewares('middlewareA', 'middlewareB'),
+
+    middlewareA(req, next) { next(); },
+    middlewareB(req, next) { next(); }
+  });
+
+  Service.create({}).get('middlewares').forEach((middleware) => {
+    assert.ok(middleware.applyMiddleware);
+  });
+});


### PR DESCRIPTION
## Proposal

This proposal adds two things:

- An API to define middlewares;
- A computed macro to do the dirty work.

## Motivation

In my app I need to define 2 middlewares: one for the authorization layer and another one for the i18n layer - using the `Accept-Language` header. The first case is practically a must-have for almost every app.

And it solves #5.

## Exemples

### Using just the middlewares API:

```javascript
import Ember from 'ember';
import ApolloService from 'ember-apollo-client/services/apollo';

const { inject: { service }, computed } = Ember;

export default ApolloService.extend({
  session: service(),
  i18n: service(),

  middlewares: computed(function() {
    return [
      { applyMiddleware: (req, next) => this.autorize(req, next) },
      { applyMiddleware: (req, next) => this.setLanguages(req, next) },
    ];
  }),

  authorize(req, next) {
    // Authorization logic
    next();
  },

  setLanguages(req, next) {
    // i18n logic
    next();
  }
});
```

### Using the macro `middlewares`:

```javascript
import Ember from 'ember';
import ApolloService from 'ember-apollo-client/services/apollo';
import middlewares from 'ember-apollo-client/utils/middlewares';

const { inject: { service }, computed } = Ember;

export default ApolloService.extend({
  session: service(),
  i18n: service(),

  middlewares: middlewares('authorize', 'setLanguages'),

  authorize(req, next) {
    // Authorization logic
    next();
  },

  setLanguages(req, next) {
    // i18n logic
    next();
  }
});
```

## Questions

### 1. Should we change the names to something more explicit? Exemple:

```javascript
{
  // ...

  networkMiddlewares: defineMiddlewares('authorize', 'setLanguages'),

  // ...
}
```

### 2. Should we support afterwares too?

```javascript
{
  // ...

  networkMiddlewares: defineMiddlewares('startResponseTimer'),

  networkAfterwares: defineAfterwares('finishResponseTimer'),

  // ...
}
```

### 3. Should we provide the macro(s) as a side project?

<hr>

Let me know what you think.