### PR TITLE
[WIP] Add mixins for reducing boilerplate code when using mutations/queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,9 @@
 # misc
 /.sass-cache
 /connect.lock
+/.idea
 /coverage/*
 /libpeerconnection.log
 npm-debug.log*
 testem.log
+

--- a/addon/mixins/apollo-mutation.js
+++ b/addon/mixins/apollo-mutation.js
@@ -1,0 +1,61 @@
+import Ember from 'ember';
+
+const {
+  Mixin,
+  inject,
+  get,
+  set,
+  assert,
+  isNone
+} = Ember;
+
+export default Mixin.create({
+  apollo: inject.service(),
+  mutations: {},
+  init(...args) {
+    this._super(...args);
+    this._registerMutations();
+  },
+  _registerMutations() {
+    const mutations = get(this, 'mutations');
+
+    for (const key in mutations) {
+      if(!mutations.hasOwnProperty(key)) {
+        continue;
+      }
+      assert(`Method is already defined '${key}'`, isNone(this[key]));
+
+      const mutationData = mutations[key];
+      this._registerMutation(key, mutationData);
+    }
+  },
+  _registerMutation(key, mutationData) {
+    const { loadingProperty } = mutationData;
+    if (loadingProperty) {
+      assert(`Property already exists '${key}'`, !this.hasOwnProperty(loadingProperty));
+      set(this, loadingProperty, 0);
+    }
+
+    const mutationMethod = function(variables = {}) {
+      const apollo = get(this, 'apollo');
+
+      const mergedVariables = Object.assign({}, (mutationData.variables || {}), variables);
+      const data = Object.assign(mutationData, { variables: mergedVariables });
+       if (loadingProperty) {
+        this.incrementProperty(loadingProperty);
+      }
+      const mutationPromise = apollo.mutate(data);
+      if (!loadingProperty) {
+        return mutationPromise;
+      }
+      return mutationPromise.then(result => {
+        this.decrementProperty(loadingProperty);
+        return result;
+      }).catch(err => {
+        this.decrementProperty(loadingProperty);
+        throw err;
+      })
+    };
+    this[key] = mutationMethod.bind(this);
+  }
+});

--- a/addon/mixins/apollo-mutation.js
+++ b/addon/mixins/apollo-mutation.js
@@ -40,6 +40,9 @@ export default Mixin.create({
       const apollo = get(this, 'apollo');
 
       const mergedVariables = Object.assign({}, (mutationData.variables || {}), variables);
+      if (typeof mutationData.optimisticResponse === 'function') {
+        mutationData.optimisticResponse = mutationData.optimisticResponse.call(this, mergedVariables);
+      }
       const data = Object.assign(mutationData, { variables: mergedVariables });
        if (loadingProperty) {
         this.incrementProperty(loadingProperty);

--- a/addon/mixins/apollo-mutation.js
+++ b/addon/mixins/apollo-mutation.js
@@ -6,7 +6,8 @@ const {
   get,
   set,
   assert,
-  isNone
+  isNone,
+  assign
 } = Ember;
 
 export default Mixin.create({
@@ -39,11 +40,12 @@ export default Mixin.create({
     const mutationMethod = function(variables = {}) {
       const apollo = get(this, 'apollo');
 
-      const mergedVariables = Object.assign({}, (mutationData.variables || {}), variables);
-      if (typeof mutationData.optimisticResponse === 'function') {
-        mutationData.optimisticResponse = mutationData.optimisticResponse.call(this, mergedVariables);
+      const mergedVariables = assign({}, (mutationData.variables || {}), variables);
+      let { optimisticResponse } = mutationData;
+      if (typeof optimisticResponse === 'function') {
+        optimisticResponse = optimisticResponse.call(this, mergedVariables);
       }
-      const data = Object.assign(mutationData, { variables: mergedVariables });
+      const data = assign({}, mutationData, { variables: mergedVariables, optimisticResponse });
        if (loadingProperty) {
         this.incrementProperty(loadingProperty);
       }

--- a/tests/unit/mixins/apollo-mutation-test.js
+++ b/tests/unit/mixins/apollo-mutation-test.js
@@ -176,3 +176,66 @@ test('it throws of there is already a property with the same key as a mutations 
     })
   })
 });
+
+test('it allows the optimisticResponse to be a function', function(assert) {
+  assert.expect(1);
+  const apolloMock = {
+    mutate: () => EPromise.resolve()
+  };
+  let ApolloMutationObject = EObject.extend(ApolloMutationMixin, {
+    apollo: apolloMock,
+  });
+  const subject = ApolloMutationObject.create({
+    mutations: {
+      updateColor: {
+        mutation: 'This should be a gql-tagged document',
+        optimisticResponse: function () {
+          assert.ok(true);
+        },
+      }
+    },
+  });
+  subject.updateColor();
+});
+
+test('it calls a optimisticResponse function with the right context', function(assert) {
+  assert.expect(1);
+  const apolloMock = {
+    mutate: () => EPromise.resolve()
+  };
+  let ApolloMutationObject = EObject.extend(ApolloMutationMixin, {
+    apollo: apolloMock,
+  });
+  const subject = ApolloMutationObject.create({
+    mutations: {
+      updateColor: {
+        mutation: 'This should be a gql-tagged document',
+        optimisticResponse: function () {
+          assert.equal(this, subject);
+        },
+      }
+    },
+  });
+  subject.updateColor();
+});
+
+test('it passes the variables into the optimisticRepsonse function', function (assert) {
+  assert.expect(1);
+  const apolloMock = {
+    mutate: () => EPromise.resolve()
+  };
+  let ApolloMutationObject = EObject.extend(ApolloMutationMixin, {
+    apollo: apolloMock,
+  });
+  const subject = ApolloMutationObject.create({
+    mutations: {
+      updateColor: {
+        mutation: 'This should be a gql-tagged document',
+        optimisticResponse: function (variables) {
+          assert.deepEqual(variables, { color: 'red' });
+        },
+      }
+    },
+  });
+  subject.updateColor({ color: 'red' })
+});

--- a/tests/unit/mixins/apollo-mutation-test.js
+++ b/tests/unit/mixins/apollo-mutation-test.js
@@ -1,0 +1,178 @@
+import Ember from 'ember';
+import ApolloMutationMixin from 'ember-apollo-client/mixins/apollo-mutation';
+import { module, test } from 'qunit';
+
+const {
+  get,
+  Object: EObject,
+  RSVP: { Promise: EPromise },
+} = Ember;
+
+module('Unit | Mixin | apollo mutation');
+
+// Replace this with your real tests.
+test('it can be created', function(assert) {
+  assert.expect(1);
+  let ApolloMutationObject = EObject.extend(ApolloMutationMixin);
+  let subject = ApolloMutationObject.create();
+  assert.ok(subject);
+});
+
+test('it creates mutation methods', function(assert) {
+  assert.expect(1);
+  const apolloMock = {
+    mutate: () => EPromise.resolve(),
+  };
+
+  let ApolloMutationObject = EObject.extend(ApolloMutationMixin, {
+    apollo: apolloMock,
+  });
+  let subject = ApolloMutationObject.create({
+    mutations: {
+      createSomething: {
+        mutation: 'Sum mutation doc',
+      }
+    }
+  });
+  assert.ok(subject.createSomething);
+});
+
+test('mutation methods call the mutate method of the service', function(assert) {
+  assert.expect(1);
+  const apolloMock = {
+    mutate: () => {
+      assert.ok(true);
+      return EPromise.resolve();
+    }
+  };
+  let ApolloMutationObject = EObject.extend(ApolloMutationMixin, {
+    apollo: apolloMock,
+  });
+  let subject = ApolloMutationObject.create({
+    mutations: {
+      createSomething: {
+        mutation: 'Sum mutation doc',
+      }
+    }
+  });
+  subject.createSomething();
+});
+
+test('it supports the loadingProperty option', function(assert) {
+  assert.expect(2);
+  const apolloMock = {
+    mutate: () => new EPromise(res => {
+      setTimeout(res, 100);
+    })
+  };
+  let ApolloMutationObject = EObject.extend(ApolloMutationMixin, {
+    apollo: apolloMock,
+  });
+  let subject = ApolloMutationObject.create({
+    mutations: {
+      createSomething: {
+        mutation: 'This should be a gql-tagged document',
+        loadingProperty: 'isCreatingSomething',
+      }
+    }
+  });
+  let promise = subject.createSomething();
+  assert.equal(get(subject, 'isCreatingSomething'), 1);
+  return promise.then(() => {
+    assert.equal(get(subject, 'isCreatingSomething'), 0);
+  })
+});
+
+test('it decrements the loadingProperty on mutation failures', function(assert) {
+  assert.expect(2);
+  const apolloMock = {
+    mutate: () => new EPromise((res, rej) => {
+      setTimeout(rej, 100);
+    })
+  };
+
+  let ApolloMutationObject = EObject.extend(ApolloMutationMixin, {
+    apollo: apolloMock,
+  });
+  let subject = ApolloMutationObject.create({
+    mutations: {
+      createSomething: {
+        mutation: 'This should be a gql-tagged document',
+        loadingProperty: 'isCreatingSomething',
+      }
+    }
+  });
+  let promise = subject.createSomething();
+  assert.equal(get(subject, 'isCreatingSomething'), 1);
+  return promise.catch(() => {
+    assert.equal(get(subject, 'isCreatingSomething'), 0);
+  });
+});
+
+test('it correctly merges variables', function(assert) {
+  assert.expect(1);
+  const apolloMock = {
+    mutate(options) {
+      assert.propEqual(options.variables, {
+        color: `red`,
+        id: 31,
+      })
+    },
+  };
+
+  let ApolloMutationObject = EObject.extend(ApolloMutationMixin, {
+    apollo: apolloMock,
+  });
+  let subject = ApolloMutationObject.create({
+    mutations: {
+      updateColor: {
+        mutation: 'This should be a gql-tagged document',
+        variables: {
+          color: `red`,
+        },
+      }
+    }
+  });
+  subject.updateColor({ id: 31 });
+});
+
+test('it throws if there is already a property with the same key as the mutation', function(assert) {
+  assert.expect(1);
+  const apolloMock = {
+    mutate: () => EPromise.resolve(),
+  };
+  let ApolloMutationObject = EObject.extend(ApolloMutationMixin, {
+    apollo: apolloMock,
+  });
+  assert.throws(() => {
+    ApolloMutationObject.create({
+      mutations: {
+        updateColor: {
+          mutation: 'This should be a gql-tagged document',
+        }
+      },
+      updateColor: true
+    })
+  });
+});
+
+test('it throws of there is already a property with the same key as a mutations loadingPropery', function(assert) {
+  assert.expect(1);
+  const apolloMock = {
+    mutate: () => EPromise.resolve(),
+  };
+  let ApolloMutationObject = EObject.extend(ApolloMutationMixin, {
+    apollo: apolloMock,
+  });
+  assert.throws(() => {
+    ApolloMutationObject.create({
+      mutations: {
+        updateColor: {
+          mutation: 'This should be a gql-tagged document',
+          loadingProperty: 'isUpdatingColor',
+        }
+      },
+      isUpdatingColor: true,
+    })
+  })
+});


### PR DESCRIPTION
I am currently writing an application that uses ember-apollo-client.
I found myself writing way too much boilerplate code for implementing mutations with loading indicators. I wrote a nice mixin that creates mutation methods and is also capable of setting a "isLoading" property without much code.

Example:
```javascript
// without mixin
import Ember from 'ember'
const { Component, inject , get, RSVP: { Promise: EPromise } } = Ember;

export default Component.extend({
  apollo: inject.service(),
  isUpdatingColor: 0,
  updateColor(variables) {
    const apollo = get(this, `apollo`)
    this.incrementProperty(`isUpdatingColor`)
    return apollo.mutate({ /* insert mutation options here */ variables }).then(result => {
      this.decrementProperty(`isUpdatingColor`)
      return EPromise.resolve(result)
    }).catch(err => {
      this.decrementProperty(`isUpdatingColor`)
      throw err
    })
  },
  actions: {
    updateColor(id, color) {
      return this.updateColor({ id, color })
    },
  },
})

// with mixin
import Ember from 'ember'
import ApolloMutationMixin from 'ember-apollo-client/mixins/apollo-mutation';
const { Component } = Ember;

export default Component.extend(ApolloMutationMixin, {
  mutations: {
    updateColor: {
      /* insert mutation options here */
      loadingProperty: `isUpdatingColor`,
    },
  },
  actions: {
    updateColor(id, color) {
      return this.updateColor({ id, color })
    },
  },
})

```
 
I am curious whether this could become part of ember-apollo-client or it should be up to the user to implement "helpers" like this on their own @bgentry ?
I would also love having a query mixin.