### PR TITLE
Import the key name correctly

### DIFF
--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import ApolloClient, { createNetworkInterface } from 'apollo-client';
-import apolloObservableKey from 'ember-apollo-client';
+import { apolloObservableKey } from 'ember-apollo-client';
 import QueryManager from 'ember-apollo-client/apollo/query-manager';
 import copyWithExtras from 'ember-apollo-client/utils/copy-with-extras';
 


### PR DESCRIPTION
Today this imports something like '[Object object]', so the observable is not being set to the proper key.

I think we should import the key between `{` `}`.