### PR TITLE
Removes ember-network in favour of ember-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "name": "ember-apollo-client",
   "version": "0.4.5",
   "description": "An ember-cli addon for the Apollo GraphQL Client.",
-  "keywords": ["ember-addon", "apollo-client", "apollo", "graphql"],
+  "keywords": [
+    "ember-addon",
+    "apollo-client",
+    "apollo",
+    "graphql"
+  ],
   "license": "MIT",
   "author": "Blake Gentry",
   "directories": {
@@ -41,8 +46,8 @@
     "ember-common-tags": "0.1.2",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
+    "ember-fetch": "^3.4.0",
     "ember-load-initializers": "^1.0.0",
-    "ember-network": "0.3.1",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.15.0",
     "eslint-plugin-ember-suave": "^1.0.0",

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 import startPretender from '../helpers/start-pretender';
-import fetch from 'ember-network/fetch';
+import fetch from 'fetch';
 
 const { RSVP: { resolve } } = Ember;
 


### PR DESCRIPTION
This substitutes' `ember-nework`[deprecated](https://github.com/tomdale/ember-network#-deprecation-notice-) `ember-fetch`. And already prepares the addon tests for the arrival of Fastboot.