### PR TITLE
handle undefined data while still loading

### DIFF
--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -31,7 +31,15 @@ function newDataFunc(observable, resultKey, resolve) {
   let mergedProps = {};
   mergedProps[apolloObservableKey] = observable;
 
-  return ({ data }) => {
+  return ({ data, loading }) => {
+    if (loading && data === undefined) {
+      // This happens when the cache has no data and the data is still loading
+      // from the server. We don't want to resolve the promise with empty data
+      // so we instead just bail out.
+      //
+      // See https://github.com/bgentry/ember-apollo-client/issues/45
+      return;
+    }
     let keyedData = isNone(resultKey) ? data : get(data, resultKey);
     let dataToSend = copyWithExtras(keyedData, [], []);
     if (isNone(obj)) {

--- a/tests/acceptance/query-and-unsubscribe-test.js
+++ b/tests/acceptance/query-and-unsubscribe-test.js
@@ -127,4 +127,4 @@ test('visiting /characters', function(assert) {
       });
     });
   });
-})
+});

--- a/tests/dummy/app/routes/luke.js
+++ b/tests/dummy/app/routes/luke.js
@@ -6,7 +6,11 @@ const variables = { id: '1000' };
 
 export default Ember.Route.extend(RouteQueryManager, {
   model() {
-    return this.apollo.watchQuery({ query, variables }, 'human');
+    return this.apollo.watchQuery({
+      query,
+      variables,
+      fetchPolicy: 'cache-and-network',
+    }, 'human');
   },
 
   actions: {


### PR DESCRIPTION
When using a 'cache-and-network' fetchPolicy, Apollo calls the
Observer's `next()` as soon as it tries to load data from the cache.
Often there is no data in the cache, so that's just undefined. This
blows up when trying to get properties from undefined.

We don't want to resolve a promise in this scenario, because data is
still loading, and Ember users expect their promises to resolve when the
data has finished loading. As such, we just bail out in this case and
wait for the eventual call to `next()` when there is actual data.

Fixes #45. Closes #56.