### PR TITLE
fix requestCredentials naming typo

### DIFF
--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -67,7 +67,7 @@ const defaultOptions = {
 export default Service.extend({
   client: null,
   apiURL: alias('options.apiURL'),
-  requestCredentials: alias('options.credentials'),
+  requestCredentials: alias('options.requestCredentials'),
 
   // options are configured in your environment.js.
   options: computed(function() {


### PR DESCRIPTION
apologies for missing this in the previous [commit](https://github.com/bgentry/ember-apollo-client/commit/2ad5b83b572253c2e7b40b050e9eb100e4a96097)

everything should be fine now