### PR TITLE
Make sure to run before ember-cli-babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "node": "^4.5 || 6.* || >= 7.*"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "before": ["ember-cli-babel"]
   }
 }


### PR DESCRIPTION
Otherwise the order that the `.graphql` preprocessor in this addon runs vs Babel itself is undefined, so folks can end up with un-transpiled ES6 `import`/`export` code in their output.