### PR TITLE
unsubscribe from watchQueries on Route.willDestroy

### DIFF
--- a/addon/mixins/route-query-manager.js
+++ b/addon/mixins/route-query-manager.js
@@ -13,4 +13,9 @@ export default Mixin.create(BaseQueryManager, {
     this._super(...arguments);
     this.get('apollo').unsubscribeAll(!isExiting);
   },
+
+  willDestroy() {
+    this.get('apollo').unsubscribeAll(false);
+    this._super(...arguments);
+  }
 });

--- a/tests/unit/mixins/route-query-manager-test.js
+++ b/tests/unit/mixins/route-query-manager-test.js
@@ -76,3 +76,33 @@ test('it only unsubscribes from stale watchQuery subscriptions with isExiting=fa
   );
   done();
 });
+
+
+test('it unsubscribes from any watchQuery subscriptions on willDestroy', function(assert) {
+  let done = assert.async();
+  let subject = this.subject();
+  let unsubscribeCalled = 0;
+
+  let apolloService = subject.get('apollo.apollo');
+  apolloService.set('managedWatchQuery', (manager, opts) => {
+    assert.deepEqual(opts, { query: 'fakeQuery' });
+    manager.trackSubscription({
+      unsubscribe() {
+        unsubscribeCalled++;
+      },
+    });
+    return {};
+  });
+
+  subject.apollo.watchQuery({ query: 'fakeQuery' });
+  subject.apollo.watchQuery({ query: 'fakeQuery' });
+
+  subject.beforeModel();
+  subject.willDestroy();
+  assert.equal(
+    unsubscribeCalled,
+    2,
+    '_apolloUnsubscribe() was called once per watchQuery'
+  );
+  done();
+});


### PR DESCRIPTION
I noticed that in some of my acceptance tests, I was seeing bizarre logs from Apollo Client after my tests had finished. This turned out to be due to queries with a `pollInterval` never actually being unsubscribed when the app was unrendered from the test div. I guess `resetController` is not called when the app is shutting down?

However, `willDestroy` is called on all routes at that time. This change makes it so `Route.willDestroy` unsubscribes from any tracked subscriptions.