### PR TITLE
don't destructure Ember.testing

### DIFF
--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -17,10 +17,6 @@ import QueryManager from 'ember-apollo-client/apollo/query-manager';
 import copyWithExtras from 'ember-apollo-client/utils/copy-with-extras';
 import { registerWaiter } from '@ember/test';
 
-const {
-  testing,
-} = Ember;
-
 function newDataFunc(observable, resultKey, resolve, mergedProps = {}) {
   let obj;
   mergedProps[apolloObservableKey] = observable;
@@ -70,7 +66,7 @@ export default Service.extend({
     let config = getOwner(this).resolveRegistration("config:environment");
     if (config && config.apollo) {
       return config.apollo;
-    } else if (testing) {
+    } else if (Ember.testing) {
       return defaultOptions;
     }
     throw new Error("no Apollo service options defined");
@@ -87,7 +83,7 @@ export default Service.extend({
     let client = new ApolloClient(this.get('clientOptions'));
     this.set('client', client);
 
-    if (testing) {
+    if (Ember.testing) {
       this._registerWaiter();
     }
   },


### PR DESCRIPTION
Module destructures are evaluated at build time, but this value is changed dynamically at runtime. Avoiding the destructure is the only way to work given this behavior. See these issues:

https://github.com/simplabs/ember-simple-auth/issues/1476
https://github.com/emberjs/ember-test-helpers/pull/227

I have confirmed that this fixes the acceptance test failures I was encountering after upgrading to Ember v2.17, where `andThen()` did not appear to be waiting for ember-apollo-client's promises to resolve.

Resolves #76. Thanks @rwjblue.