### PR TITLE
Install this addon after ember-cli-shims

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "node": "^4.5 || 6.* || >= 7.*"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "after": "ember-cli-shims"
   }
 }


### PR DESCRIPTION
### What?
Install this addon after `ember-cli-shims`

### Why?
Without this clause, on some versions of Ember an error is thrown in the likes of: 
```js
Error: Could not find module `@ember/service` imported from `ember-apollo-client/services/apollo`
```
For more information, see this [comment](https://github.com/thefrontside/ember-let/issues/36#issuecomment-296438695) by @rwj.

### How?
Add to the package.json the option to install this addon after ember-cli-shims.