### PR TITLE
Forward QueryManager.mutate()'s resultKey to service

### DIFF
--- a/addon/apollo/query-manager.js
+++ b/addon/apollo/query-manager.js
@@ -22,8 +22,8 @@ export default EmberObject.extend({
    * @return {!Promise}
    * @public
    */
-  mutate(opts) {
-    return this.get('apollo').mutate(opts);
+  mutate(opts, resultKey) {
+    return this.get('apollo').mutate(opts, resultKey);
   },
 
   /**


### PR DESCRIPTION
Thanks for building this addon!
  
The `resultKey` argument was missing here.