### PR TITLE
README: middlewares example which fits 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,10 @@ The `apollo` service has the following public API:
 
     authorize(req, next) {
       // Authorization logic
+      if (!req.options.headers) {
+        req.options.headers = {};
+      }
+      req.options.headers.authorization = "Bearer my-actual-auth-token";
       next();
     }
   });


### PR DESCRIPTION
This PR adds example code to show how middlewares in 1.x can access the HTTP headers for `req`.

I got the inspiration for this in the Upgrade Notes: https://github.com/apollographql/apollo-client/blob/master/Upgrade.md#upgrading-from-custom-networkinterface-with-middleware--afterware 