### PR TITLE
Apollo client 2.0 init fixes

### DIFF
--- a/addon/mixins/base-query-manager.js
+++ b/addon/mixins/base-query-manager.js
@@ -1,13 +1,11 @@
 import { inject as service } from "@ember/service";
 import Mixin from "@ember/object/mixin";
+import { computed } from "@ember/object"
 
 export default Mixin.create({
   apolloService: service('apollo'),
 
-  init() {
-    this._super(...arguments);
-
-    let queryManager = this.get('apolloService').createQueryManager();
-    this.set('apollo', queryManager);
-  },
+  apollo: computed(function() {
+    return this.get('apolloService').createQueryManager();
+  })
 });

--- a/addon/mixins/base-query-manager.js
+++ b/addon/mixins/base-query-manager.js
@@ -2,12 +2,12 @@ import { inject as service } from "@ember/service";
 import Mixin from "@ember/object/mixin";
 
 export default Mixin.create({
-  apollo: service(),
+  apolloService: service('apollo'),
 
   init() {
     this._super(...arguments);
 
-    let queryManager = this.get('apollo').createQueryManager();
+    let queryManager = this.get('apolloService').createQueryManager();
     this.set('apollo', queryManager);
   },
 });

--- a/tests/dummy/app/routes/characters.js
+++ b/tests/dummy/app/routes/characters.js
@@ -10,6 +10,6 @@ export default Route.extend(RouteQueryManager, {
   },
 
   model(variables) {
-    return this.apollo.watchQuery({ query, variables }, 'characters');
+    return this.get('apollo').watchQuery({ query, variables }, 'characters');
   }
 });

--- a/tests/dummy/app/routes/luke.js
+++ b/tests/dummy/app/routes/luke.js
@@ -6,7 +6,7 @@ const variables = { id: '1000' };
 
 export default Route.extend(RouteQueryManager, {
   model() {
-    return this.apollo.watchQuery({
+    return this.get('apollo').watchQuery({
       query,
       variables,
       fetchPolicy: 'cache-and-network',
@@ -15,7 +15,7 @@ export default Route.extend(RouteQueryManager, {
 
   actions: {
     refetchModel() {
-      this.apollo.query({
+      this.get('apollo').query({
         query,
         variables,
         fetchPolicy: 'network-only',

--- a/tests/unit/mixins/component-query-manager-test.js
+++ b/tests/unit/mixins/component-query-manager-test.js
@@ -31,8 +31,8 @@ test('it unsubscribes from any watchQuery subscriptions', function(assert) {
     return {};
   });
 
-  subject.apollo.watchQuery({ query: 'fakeQuery' });
-  subject.apollo.watchQuery({ query: 'fakeQuery' });
+  subject.get('apollo').watchQuery({ query: 'fakeQuery' });
+  subject.get('apollo').watchQuery({ query: 'fakeQuery' });
 
   subject.willDestroyElement();
   assert.equal(

--- a/tests/unit/mixins/object-query-manager-test.js
+++ b/tests/unit/mixins/object-query-manager-test.js
@@ -31,8 +31,8 @@ test('it unsubscribes from any watchQuery subscriptions', function(assert) {
     return {};
   });
 
-  subject.apollo.watchQuery({ query: 'fakeQuery' });
-  subject.apollo.watchQuery({ query: 'fakeQuery' });
+  subject.get('apollo').watchQuery({ query: 'fakeQuery' });
+  subject.get('apollo').watchQuery({ query: 'fakeQuery' });
 
   subject.willDestroy();
   assert.equal(

--- a/tests/unit/mixins/route-query-manager-test.js
+++ b/tests/unit/mixins/route-query-manager-test.js
@@ -32,8 +32,8 @@ test('it unsubscribes from any watchQuery subscriptions with isExiting=true', fu
     return {};
   });
 
-  subject.apollo.watchQuery({ query: 'fakeQuery' });
-  subject.apollo.watchQuery({ query: 'fakeQuery' });
+  subject.get('apollo').watchQuery({ query: 'fakeQuery' });
+  subject.get('apollo').watchQuery({ query: 'fakeQuery' });
 
   subject.beforeModel();
   subject.resetController({}, true);
@@ -61,11 +61,11 @@ test('it only unsubscribes from stale watchQuery subscriptions with isExiting=fa
     return {};
   });
 
-  subject.apollo.watchQuery({ query: 'fakeQuery' });
+  subject.get('apollo').watchQuery({ query: 'fakeQuery' });
 
   // simulate data being re-fetched, as when query params change
   subject.beforeModel();
-  subject.apollo.watchQuery({ query: 'fakeQuery' });
+  subject.get('apollo').watchQuery({ query: 'fakeQuery' });
 
   subject.resetController({}, false);
   assert.equal(
@@ -93,8 +93,8 @@ test('it unsubscribes from any watchQuery subscriptions on willDestroy', functio
     return {};
   });
 
-  subject.apollo.watchQuery({ query: 'fakeQuery' });
-  subject.apollo.watchQuery({ query: 'fakeQuery' });
+  subject.get('apollo').watchQuery({ query: 'fakeQuery' });
+  subject.get('apollo').watchQuery({ query: 'fakeQuery' });
 
   subject.beforeModel();
   subject.willDestroy();


### PR DESCRIPTION
This lazy initializes the query manager.

The downside is that you will basically always have to do `this.get("apollo")` instead of `this.apollo`. This is why the tests are failing, and I'll have to fix them before merging. But I believe this is the correct way anyway, and it's what ember-data recommends everywhere too now.

These fixes helped me upgrade my app to Ember v3.0.

Thanks @turbo87 for helping me track this down as a partial source of my bugs.