### PR TITLE
replace deprecated queryOnce w/ query

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ The `apollo` service has the following public API:
 
   When using this method, **it is important to [unsubscribe][unsubscribing]**
   from the query when you're done with it.
-* `queryOnce(options, resultKey)`: This calls the
+* `query(options, resultKey)`: This calls the
   [`ApolloClient.query`](http://dev.apollodata.com/core/apollo-client-api.html#ApolloClient\.query)
   method. It returns a promise that resolves with the raw POJO data that the
   query returns. If you provide a `resultKey`, the resolved data is grabbed from

--- a/addon/apollo/query-manager.js
+++ b/addon/apollo/query-manager.js
@@ -30,14 +30,14 @@ export default EmberObject.extend({
    * Executes a single `query` on the Apollo service. The resolved object will
    * never be updated and does not have to be unsubscribed.
    *
-   * @method queryOnce
+   * @method query
    * @param {!Object} opts The query options used in the Apollo Client query.
    * @param {String} resultKey The key that will be returned from the resulting response data. If null or undefined, the entire response data will be returned.
    * @return {!Promise}
    * @public
    */
   query(opts, resultKey) {
-    return this.get('apollo').queryOnce(opts, resultKey);
+    return this.get('apollo').query(opts, resultKey);
   },
 
   /**

--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -182,30 +182,6 @@ export default Service.extend({
    * the resolved data when the route or component is torn down. That tells
    * Apollo to stop trying to send updated data to a non-existent listener.
    *
-   * @method query
-   * @param {!Object} opts The query options used in the Apollo Client watchQuery.
-   * @param {String} resultKey The key that will be returned from the resulting response data. If null or undefined, the entire response data will be returned.
-   * @deprecated Use `watchQuery` instead.
-   * @return {!Promise}
-   * @public
-   */
-  query(opts, resultKey) {
-    deprecate(`Usage of \`query\` is deprecated, use \`watchQuery\` instead.`, false, {
-      id: 'ember-apollo-client.deprecate-query-for-watch-query',
-      until: '1.0.0',
-    });
-    return this.watchQuery(opts, resultKey);
-  },
-
-  /**
-   * Executes a `watchQuery` on the Apollo client. If updated data for this
-   * query is loaded into the store by another query, the resolved object will
-   * be updated with the new data.
-   *
-   * When using this method, it is important to call `apolloUnsubscribe()` on
-   * the resolved data when the route or component is torn down. That tells
-   * Apollo to stop trying to send updated data to a non-existent listener.
-   *
    * @method watchQuery
    * @param {!Object} opts The query options used in the Apollo Client watchQuery.
    * @param {String} resultKey The key that will be returned from the resulting response data. If null or undefined, the entire response data will be returned.
@@ -240,13 +216,13 @@ export default Service.extend({
    * Executes a single `query` on the Apollo client. The resolved object will
    * never be updated and does not have to be unsubscribed.
    *
-   * @method queryOnce
+   * @method query
    * @param {!Object} opts The query options used in the Apollo Client query.
    * @param {String} resultKey The key that will be returned from the resulting response data. If null or undefined, the entire response data will be returned.
    * @return {!Promise}
    * @public
    */
-  queryOnce(opts, resultKey) {
+  query(opts, resultKey) {
     return this._waitFor(
       this.client.query(opts).then(result => {
         let response = result.data;

--- a/tests/acceptance/query-and-unsubscribe-test.js
+++ b/tests/acceptance/query-and-unsubscribe-test.js
@@ -45,7 +45,7 @@ test('visiting /luke', function(assert) {
     assert.equal(currentURL(), '/luke');
     assert.equal(find('.model-name').text(), 'Luke Skywalker');
 
-    // try updating the mock, refetching the result (w/ queryOnce), and ensuring
+    // try updating the mock, refetching the result (w/ query), and ensuring
     // that there are no errors:
     human.name = 'Lucas Skywalker';
     click('.refetch-button');


### PR DESCRIPTION
One last fix before I cut the v1.0 beta. The `query` method on the Apollo service has been deprecated for a long time (originally that was how you'd do a `watchQuery`). Now I can finally drop that method and rename `queryOnce` to `query` so the API between the query manager and the service are aligned.