### PR TITLE
Use raw graphql schema

### DIFF
--- a/.gqlconfig
+++ b/.gqlconfig
@@ -1,0 +1,35 @@
+ {
+   schema: {
+     files: 'tests/fixtures/test-schema.graphql'
+   },
+   query: {
+     files: [
+       // query gql files
+       {
+         match: 'app/gql/**/*.graphql',
+         parser: 'QueryParser',
+         // required until fragment imports work: https://github.com/Mayank1791989/gql/issues/3
+         validate: {
+           extends: "gql-rules-query",
+           rules: {
+             KnownFragmentNames: "off",
+             NoUnusedFragments: "off"
+           }
+         }
+       },
+       // [Embedded queries] gql tag files
+       {
+         match: { include: 'app/**/*.js' },
+         parser: [ 'EmbeddedQueryParser', { startTag: 'gql`', endTag: '`' } ],
+         // required until fragment imports work: https://github.com/Mayank1791989/gql/issues/3
+         validate: {
+           extends: "gql-rules-query",
+           rules: {
+             KnownFragmentNames: "off",
+             NoUnusedFragments: "off"
+           }
+         }
+       },
+     ],
+   },
+ }

--- a/tests/fixtures/test-schema.graphql
+++ b/tests/fixtures/test-schema.graphql
@@ -1,4 +1,3 @@
-const schema = `
 schema {
   query: Query
   mutation: Mutation
@@ -134,6 +133,3 @@ type Starship {
 }
 
 union SearchResult = Human | Droid | Starship
-`;
-
-export default schema;

--- a/tests/helpers/start-pretender.js
+++ b/tests/helpers/start-pretender.js
@@ -6,7 +6,7 @@ import {
   addResolveFunctionsToSchema,
   makeExecutableSchema,
 } from 'graphql-tools';
-import schemaString from '../fixtures/test-schema.graphql';
+import schemaString from '../fixtures/test-schema';
 
 const interfaceResolveType = {
   __resolveType(data) {


### PR DESCRIPTION
Rather than wrapping this in a `.js` file, we can rely on this addon's build capabilities for `.graphql` files. This also makes it compatible with [gql schema validation](https://github.com/Mayank1791989/gql) as is used in the VS Code [GraphQL addon](https://github.com/kumarharsh/graphql-for-vscode).