### PR TITLE
Fixes an error when running default blueprint

### DIFF
--- a/blueprints/ember-apollo-client/index.js
+++ b/blueprints/ember-apollo-client/index.js
@@ -2,13 +2,15 @@
 module.exports = {
   description: 'Add ember-fetch in the consumer app',
 
+  normalizeEntityName() {},
+
   /*
   * This is necessary until this is fixed
   * https://github.com/ember-cli/ember-fetch/issues/98
   */
   afterInstall() {
     return this.addPackagesToProject([
-      {name: 'ember-fetch', target: '^3.4.4'}
+      { name: 'ember-fetch', target: '^3.4.4' }
     ]);
   }
 };


### PR DESCRIPTION
Without this change, installation of the adddon fails with "the `ember generate <entity-name>` command requires an entity name to be specified."

To fix it, we add a `normalizeEntityName` function to the blueprint.

Before:
![image](https://user-images.githubusercontent.com/14339/36406481-3583a262-15c5-11e8-856a-819b5ea23ed9.png)

After:
![image](https://user-images.githubusercontent.com/14339/36406568-d39d8558-15c5-11e8-8478-cb1652439de9.png)


