### PR TITLE
Alias apollo client in QueryManager

### DIFF
--- a/addon/apollo/query-manager.js
+++ b/addon/apollo/query-manager.js
@@ -1,10 +1,12 @@
 import { inject as service } from "@ember/service";
 import EmberObject from "@ember/object";
+import { alias } from "@ember/object/computed";
 import { A } from "@ember/array";
 
 export default EmberObject.extend({
   apollo: service(),
-
+  client: alias('apollo.client'),
+  
   activeSubscriptions: null,
 
   init() {

--- a/tests/unit/mixins/object-query-manager-test.js
+++ b/tests/unit/mixins/object-query-manager-test.js
@@ -1,5 +1,6 @@
 import EmberObject from '@ember/object';
 import ObjectQueryManagerMixin from 'ember-apollo-client/mixins/object-query-manager';
+import { ApolloClient } from 'apollo-client';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
@@ -40,5 +41,11 @@ module('Unit | Mixin | ember object query manager', function(hooks) {
       '_apolloUnsubscribe() was called once per watchQuery'
     );
     done();
+  });
+
+  test('it exposes an apollo client object', function(assert) {
+    let subject = this.subject();
+    let client = subject.get('apollo.client');
+    assert.ok(client instanceof ApolloClient);
   });
 });


### PR DESCRIPTION
There are some instances where it makes sense to drop down to the Apollo client library when calling specialized functions. For example`client.reFetchObservableQueries()`