### PR TITLE
cleanup _waitFor in Apollo service

### DIFF
--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -273,14 +273,7 @@ export default Service.extend({
   _waitFor(promise) {
     this._incrementOngoing();
     return promise
-      .then(result => {
-        this._decrementOngoing();
-        return result;
-      })
-      .catch(err => {
-        this._decrementOngoing();
-        return RSVP.reject(err);
-      });
+      .finally(() => this._decrementOngoing());
   },
 
   // unresolved / ongoing requests, used for tests:


### PR DESCRIPTION
All we actually care about is just always decrementing the query counter, so we shouldn't have to mess with `then`/`catch`.

Does this make sense?