### PR TITLE
Lets user specify optional packages at build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - "6"
 
 sudo: required
 dist: trusty

--- a/README.md
+++ b/README.md
@@ -53,13 +53,15 @@ The application built in the tutorial is also available on the [How To GraphQL r
 
 ## Configuration
 
-In your app's `config/environment.js`, configure the URL for the GraphQL API:
+In your app's `config/environment.js`, configure the URL for the GraphQL API. Here, you can also include additional Apollo packages that haven't been included by default. Valid package names can be found [here](https://github.com/apollographql/apollo-link/tree/master/packages)
+
 
 ```js
 let ENV = {
   ...
   apollo: {
     apiURL: 'https://test.example/graphql',
+    include: ['apollo-link-batch-http', 'apollo-link-persisted-queries'],
     // Optionally, set the credentials property of the Fetch Request interface
     // to control when a cookie is sent:
     // requestCredentials: 'same-origin', // other choices: 'include', 'omit'
@@ -72,20 +74,6 @@ Additional configuration of the ApolloClient can be done by extending the Apollo
 service and overriding the `clientOptions` property. See the
 [Apollo Service API][apollo-service-api] for more info.
 
-Specify any optional Apollo packages you wish to include at build time in `ember-cli-build.js`:
-
-
-```js
-  let app = new EmberApp(defaults, {
-    ...
-    'ember-apollo-client': {
-      include: ['apollo-link-batch-http', 'apollo-link-persisted-queries'],
-    },
-    ...
-  }
-```
-
-Valid package names can be found [here](https://github.com/apollographql/apollo-link/tree/master/packages)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@ Additional configuration of the ApolloClient can be done by extending the Apollo
 service and overriding the `clientOptions` property. See the
 [Apollo Service API][apollo-service-api] for more info.
 
+Specify any optional Apollo packages you wish to include at build time in `ember-cli-build.js`:
+
+
+```js
+  let app = new EmberApp(defaults, {
+    ...
+    'ember-apollo-client': {
+      include: ['apollo-link-batch-http', 'apollo-link-persisted-queries'],
+    },
+    ...
+  }
+```
+
+Valid package names can be found [here](https://github.com/apollographql/apollo-link/tree/master/packages)
+
 ## Usage
 
 ### Fetching data

--- a/README.md
+++ b/README.md
@@ -57,12 +57,6 @@ The application built in the tutorial is also available on the [How To GraphQL r
 
 In your app's `config/environment.js`, configure the URL for the GraphQL API.
 
-Here, you can specify additional Apollo packages to include, as well as packages to exclude from the build.
-
-_Note: included packages must also be explicitly installed as development dependencies in `package.json`._
-
-Valid package names can be found [here](https://github.com/apollographql/apollo-link/tree/master/packages).
-
 ```js
 let ENV = {
   ...
@@ -76,6 +70,22 @@ let ENV = {
   },
   ...
 }
+```
+
+In `ember-cli-build.js`, you can specify additional Apollo packages to include, as well as packages to exclude from the build.
+
+_Note: included packages must also be explicitly installed as development dependencies in `package.json`._
+
+Valid package names can be found [here](https://github.com/apollographql/apollo-link/tree/master/packages).
+
+```js
+  let app = new EmberApp(defaults, {
+  ...
+    apollo: {
+      include: ['apollo-link-batch-http'],
+      exclude: ['graphql-tag'],
+    },
+  })
 ```
 
 Additional configuration of the ApolloClient can be done by extending the Apollo

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ember-apollo-client
 
-*Use [apollo-client][apollo-client] and GraphQL from your Ember app.*
+_Use [apollo-client][apollo-client] and GraphQL from your Ember app._
 
 ![Download count all time](https://img.shields.io/npm/dt/ember-apollo-client.svg) [![npm version](https://badge.fury.io/js/ember-apollo-client.svg)](https://badge.fury.io/js/ember-apollo-client) [![Travis CI Build Status](https://travis-ci.org/bgentry/ember-apollo-client.svg?branch=master)](https://travis-ci.org/bgentry/ember-apollo-client) [![Ember Observer Score](https://emberobserver.com/badges/ember-apollo-client.svg)](https://emberobserver.com/addons/ember-apollo-client)
 
@@ -41,20 +41,25 @@ This should also automatically install `ember-fetch`.
 Install the [Apollo Client Developer tools for Chrome](https://chrome.google.com/webstore/detail/apollo-client-developer-t/jdkknkkbebbapilgoeccciglkfbmbnfm) for a great GraphQL developer experience!
 
 ## Compatibility
+
 This addon works and is fully tested with:
 
 * Ember.js 2.12+
 * FastBoot 1.0+
 
 ## Example App
+
 If you are looking for a full tutorial using `ember-apollo-client` check out the tutorial on [How To GraphQL](https://howtographql.com), written by [DevanB](https://github.com/DevanB).
 
 The application built in the tutorial is also available on the [How To GraphQL repository](http://github.com/howtographql/ember-apollo).
 
 ## Configuration
 
-In your app's `config/environment.js`, configure the URL for the GraphQL API. Here, you can also include additional Apollo packages that haven't been included by default. Valid package names can be found [here](https://github.com/apollographql/apollo-link/tree/master/packages)
+In your app's `config/environment.js`, configure the URL for the GraphQL API.
 
+Here, you can specify additional Apollo packages to include, and packages that you want to remove from the build. and Valid package names can be found [here](https://github.com/apollographql/apollo-link/tree/master/packages).
+
+_Note: included packages must also be explicitly installed as development dependencies in `package.json`._
 
 ```js
 let ENV = {
@@ -62,6 +67,7 @@ let ENV = {
   apollo: {
     apiURL: 'https://test.example/graphql',
     include: ['apollo-link-batch-http', 'apollo-link-persisted-queries'],
+    exclude: ['graphql-tag']
     // Optionally, set the credentials property of the Fetch Request interface
     // to control when a cookie is sent:
     // requestCredentials: 'same-origin', // other choices: 'include', 'omit'
@@ -74,7 +80,6 @@ Additional configuration of the ApolloClient can be done by extending the Apollo
 service and overriding the `clientOptions` property. See the
 [Apollo Service API][apollo-service-api] for more info.
 
-
 ## Usage
 
 ### Fetching data
@@ -83,6 +88,7 @@ GraphQL queries should be placed in external files, which are automatically
 made available for import:
 
 `app/gql/queries/human.graphql`
+
 ```graphql
 query human($id: String!) {
   human(id: $id) {
@@ -110,6 +116,7 @@ Within your routes, you can query for data using the `RouteQueryManager`
 mixin and `watchQuery`:
 
 `app/routes/some-route.js`
+
 ```js
 import Route from "@ember/routing/route";
 import RouteQueryManager from "ember-apollo-client/mixins/route-query-manager";
@@ -174,6 +181,7 @@ same model(s).
 The following example shows both mutations and fragments in action:
 
 `app/gql/fragments/review-fragment.graphql`
+
 ```graphql
 fragment ReviewFragment on Human {
   stars
@@ -182,6 +190,7 @@ fragment ReviewFragment on Human {
 ```
 
 `app/gql/mutations/create-review.graphql`
+
 ```graphql
 #import 'my-app/gql/fragments/review-fragment'
 
@@ -195,6 +204,7 @@ mutation createReview($ep: Episode!, $review: ReviewInput!) {
 ```
 
 `app/routes/my-route.js`
+
 ```js
 import Route from "@ember/routing/route";
 import { inject as service } from "@ember/service";
@@ -226,13 +236,14 @@ export default Route.extend({
   can be used to resolve beneath the root.
 
   The query manager will automatically unsubscribe from this object.
+
 * `query(options, resultKey)`: This calls the
-  [`ApolloClient.query`](http://dev.apollodata.com/core/apollo-client-api.html#ApolloClient\.query)
+  [`ApolloClient.query`](http://dev.apollodata.com/core/apollo-client-api.html#ApolloClient.query)
   method. It returns a promise that resolves with the raw POJO data that the
   query returns. If you provide a `resultKey`, the resolved data is grabbed from
   that key in the result.
 * `mutate(options, resultKey)`: This calls the
-  [`ApolloClient.mutate`](http://dev.apollodata.com/core/apollo-client-api.html#ApolloClient\.mutate)
+  [`ApolloClient.mutate`](http://dev.apollodata.com/core/apollo-client-api.html#ApolloClient.mutate)
   method. It returns a promise that resolves with the raw POJO data that the
   mutation returns. As with the query methods, the `resultKey` can be used to
   resolve beneath the root.
@@ -253,12 +264,13 @@ The `apollo` service has the following public API:
     clientOptions: computed(function() {
       return {
         link: this.get("link"),
-        cache: this.get("cache"),
+        cache: this.get("cache")
       };
-    }),
+    })
   });
   ```
 * `link`: This computed property provides a list of [middlewares and afterwares](https://www.apollographql.com/docs/react/basics/network-layer.html#network-interfaces) to the [Apollo Link](https://www.apollographql.com/docs/link/) the interface for fetching and modifying control flow of GraphQL requests. To create your middlewares/afterwares:
+
   ```js
     link: computed(function() {
       let httpLink = this._super(...arguments);
@@ -290,6 +302,7 @@ The `apollo` service has the following public API:
   ```
 
   Example with ESA:
+
   ```js
   import { computed } from "@ember/object";
   import { inject as service } from "@ember/service";
@@ -314,17 +327,19 @@ The `apollo` service has the following public API:
         return {};
       }
       return new RSVPPromise(success => {
-        this.get(
-          "session"
-        ).authorize("authorizer:oauth2", (headerName, headerContent) => {
-          let headers = {};
-          headers[headerName] = headerContent;
-          success({ headers });
-        });
+        this.get("session").authorize(
+          "authorizer:oauth2",
+          (headerName, headerContent) => {
+            let headers = {};
+            headers[headerName] = headerContent;
+            success({ headers });
+          }
+        );
       });
-    },
+    }
   });
   ```
+
 * `watchQuery(options, resultKey)`: This calls the
   [`ApolloClient.watchQuery`][watch-query] method. It returns a promise that
   resolves with an `Ember.Object`. That object will be updated whenever the
@@ -333,13 +348,14 @@ The `apollo` service has the following public API:
 
   When using this method, **it is important to [unsubscribe][unsubscribing]**
   from the query when you're done with it.
+
 * `query(options, resultKey)`: This calls the
-  [`ApolloClient.query`](http://dev.apollodata.com/core/apollo-client-api.html#ApolloClient\.query)
+  [`ApolloClient.query`](http://dev.apollodata.com/core/apollo-client-api.html#ApolloClient.query)
   method. It returns a promise that resolves with the raw POJO data that the
   query returns. If you provide a `resultKey`, the resolved data is grabbed from
   that key in the result.
 * `mutate(options, resultKey)`: This calls the
-  [`ApolloClient.mutate`](http://dev.apollodata.com/core/apollo-client-api.html#ApolloClient\.mutate)
+  [`ApolloClient.mutate`](http://dev.apollodata.com/core/apollo-client-api.html#ApolloClient.mutate)
   method. It returns a promise that resolves with the raw POJO data that the
   mutation returns. As with the query methods, the `resultKey` can be used to
   resolve beneath the root.
@@ -365,6 +381,7 @@ routes. If you want to inject this mixin into all routes, you should utilize
 a base route class:
 
 `app/routes/base.js`
+
 ```js
 import Route from "@ember/routing/route";
 import RouteQueryManager from "ember-apollo-client/mixins/route-query-manager";
@@ -375,6 +392,7 @@ export default Route.extend(RouteQueryManager);
 Then extend from that in your other routes:
 
 `app/routes/a-real-route.js`
+
 ```js
 import Base from "my-app/routes/base";
 
@@ -384,23 +402,27 @@ export default Base.extend(
 ```
 
 ### Use with Fastboot
+
 Ember Apollo Client works with FastBoot out of the box as long that SSR is enabled. In order to enable SSR, define it on apollo service:
 
 Example:
+
 ```js
-  const OverriddenService = ApolloService.extend({
-    clientOptions: computed(function() {
-      return {
-        ssrMode: true,
-        link: this.get("link"),
-        cache: this.get("cache"),
-      };
-    }),
-  });
-  ```
+const OverriddenService = ApolloService.extend({
+  clientOptions: computed(function() {
+    return {
+      ssrMode: true,
+      link: this.get("link"),
+      cache: this.get("cache")
+    };
+  })
+});
+```
+
 Since you only want to fetch each query result once, pass the `ssrMode: true` option to the Apollo Client constructor to avoid repeated force-fetching.
 
 #### Skipping queries for SSR
+
 If you want to intentionally skip a query during SSR, you can pass `ssr: false` in the query options. Typically, this will mean the component will get rendered in its loading state on the server. For example:
 
 ```js
@@ -473,7 +495,7 @@ A special thanks to the following contributors:
 [observable-query]: http://dev.apollodata.com/core/apollo-client-api.html#ObservableQuery
 [query-manager-api]: #query-manager-api
 [unsubscribing]: #unsubscribing-from-watch-queries
-[watch-query]: http://dev.apollodata.com/core/apollo-client-api.html#ApolloClient\.watchQuery
+[watch-query]: http://dev.apollodata.com/core/apollo-client-api.html#ApolloClient.watchQuery
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,11 @@ The application built in the tutorial is also available on the [How To GraphQL r
 
 In your app's `config/environment.js`, configure the URL for the GraphQL API.
 
-Here, you can specify additional Apollo packages to include, and packages that you want to remove from the build. and Valid package names can be found [here](https://github.com/apollographql/apollo-link/tree/master/packages).
+Here, you can specify additional Apollo packages to include, as well as packages to exclude from the build.
 
 _Note: included packages must also be explicitly installed as development dependencies in `package.json`._
+
+Valid package names can be found [here](https://github.com/apollographql/apollo-link/tree/master/packages).
 
 ```js
 let ENV = {

--- a/index.js
+++ b/index.js
@@ -10,24 +10,24 @@ const defaultPackages = [
   'graphql',
   'graphql-tools',
   'graphql-tag',
-]
+];
 
 module.exports = {
   name: 'ember-apollo-client',
 
   included(app) {
-    this._super.included.apply(this, arguments)
+    this._super.included.apply(this, arguments);
     
-    let config = app.project.config(app.env) || {}
-    this.addonConfig = config['apollo'] || {}
+    let config = app.project.config(app.env) || {};
+    this.addonConfig = config['apollo'] || {};
     
-    this.import('vendor/-apollo-client-bundle.js')
-    this.import('vendor/-apollo-client-shims.js')
+    this.import('vendor/-apollo-client-bundle.js');
+    this.import('vendor/-apollo-client-shims.js');
   },
   
   treeForVendor() {
-    const WebpackDependencyPlugin = require('./lib/webpack-dependency-plugin')
-    const userSpecifiedPackages = this.addonConfig.include
+    const WebpackDependencyPlugin = require('./lib/webpack-dependency-plugin');
+    const userSpecifiedPackages = this.addonConfig.include;
     
     return new WebpackDependencyPlugin({
       outputName: 'apollo-client',
@@ -41,10 +41,10 @@ module.exports = {
         name: 'ember-apollo-client',
         ext: 'graphql',
         toTree(tree) {
-          const GraphQLFilter = require('./lib/graphql-filter')
-          return new GraphQLFilter(tree)
-        },
-      })
+          const GraphQLFilter = require('./lib/graphql-filter');
+          return new GraphQLFilter(tree);
+        }
+      });
     }
-  },
-}
+  }
+};

--- a/index.js
+++ b/index.js
@@ -15,9 +15,9 @@ const apolloClientDefaultPackages = [
 module.exports = {
   name: "ember-apollo-client",
 
-  included({ project, env }) {
+  included() {
     this._super.included.apply(this, arguments);
-    this.addonConfig = project.config(env)["apollo"] || {};
+    this.addonConfig = this.app.options["apollo"] || {};
 
     this.import("vendor/-apollo-client-bundle.js");
     this.import("vendor/-apollo-client-shims.js");
@@ -26,11 +26,10 @@ module.exports = {
   treeForVendor() {
     const WebpackDependencyPlugin = require("./lib/webpack-dependency-plugin");
     const {
-      addonConfig: {
-        include: userPackages = [],
-        exclude: excludedPackages = []
-      }
-    } = this;
+      include: userPackages = [],
+      exclude: excludedPackages = []
+    } = this.addonConfig;
+
     const includedPackages = apolloClientDefaultPackages.filter(
       p => !excludedPackages.includes(p)
     );

--- a/index.js
+++ b/index.js
@@ -1,47 +1,50 @@
-'use strict'
+"use strict";
 
-const defaultPackages = [
-  'apollo-cache',
-  'apollo-cache-inmemory',
-  'apollo-client',
-  'apollo-link',
-  'apollo-link-context',
-  'apollo-link-http',
-  'graphql',
-  'graphql-tools',
-  'graphql-tag',
+const apolloClientDefaultPackages = [
+  "apollo-cache",
+  "apollo-cache-inmemory",
+  "apollo-client",
+  "apollo-link",
+  "apollo-link-context",
+  "apollo-link-http",
+  "graphql",
+  "graphql-tools",
+  "graphql-tag"
 ];
 
 module.exports = {
-  name: 'ember-apollo-client',
+  name: "ember-apollo-client",
 
-  included(app) {
+  included({ project, env }) {
     this._super.included.apply(this, arguments);
-    
-    let config = app.project.config(app.env) || {};
-    this.addonConfig = config['apollo'] || {};
-    
-    this.import('vendor/-apollo-client-bundle.js');
-    this.import('vendor/-apollo-client-shims.js');
+    this.addonConfig = project.config(env)["apollo"] || {};
+
+    this.import("vendor/-apollo-client-bundle.js");
+    this.import("vendor/-apollo-client-shims.js");
   },
-  
+
   treeForVendor() {
-    const WebpackDependencyPlugin = require('./lib/webpack-dependency-plugin');
-    const userSpecifiedPackages = this.addonConfig.include;
-    
+    const WebpackDependencyPlugin = require("./lib/webpack-dependency-plugin");
+    const {
+      addonConfig: { include: userPackages, exclude: excludedPackages }
+    } = this;
+    const includedPackages = apolloClientDefaultPackages.filter(
+      p => !excludedPackages.includes(p)
+    );
+
     return new WebpackDependencyPlugin({
-      outputName: 'apollo-client',
-      expose: [...defaultPackages, ...userSpecifiedPackages],
-    })
+      outputName: "apollo-client",
+      expose: [...includedPackages, ...userPackages]
+    });
   },
-  
+
   setupPreprocessorRegistry(type, registry) {
-    if (type === 'parent') {
-      registry.add('js', {
-        name: 'ember-apollo-client',
-        ext: 'graphql',
+    if (type === "parent") {
+      registry.add("js", {
+        name: "ember-apollo-client",
+        ext: "graphql",
         toTree(tree) {
-          const GraphQLFilter = require('./lib/graphql-filter');
+          const GraphQLFilter = require("./lib/graphql-filter");
           return new GraphQLFilter(tree);
         }
       });

--- a/index.js
+++ b/index.js
@@ -1,32 +1,37 @@
-'use strict';
+'use strict'
+
+const defaultOptions = [
+  'apollo-cache',
+  'apollo-cache-inmemory',
+  'apollo-client',
+  'apollo-link',
+  'apollo-link-context',
+  'apollo-link-http',
+  'graphql',
+  'graphql-tools',
+  'graphql-tag',
+]
 
 module.exports = {
   name: 'ember-apollo-client',
 
-  included() {
-    this._super.included.apply(this, arguments);
+  included(app) {
+    this._super.included.apply(this, arguments)
 
-    this.import('vendor/-apollo-client-bundle.js');
-    this.import('vendor/-apollo-client-shims.js');
+    this.options['ember-apollo-client'] = app.options['ember-apollo-client']
+
+    this.import('vendor/-apollo-client-bundle.js')
+    this.import('vendor/-apollo-client-shims.js')
   },
 
   treeForVendor() {
-    const WebpackDependencyPlugin = require('./lib/webpack-dependency-plugin');
+    const WebpackDependencyPlugin = require('./lib/webpack-dependency-plugin')
+    const userOptions = this.options['ember-apollo-client'].include
 
     return new WebpackDependencyPlugin({
       outputName: 'apollo-client',
-      expose: [
-        'apollo-cache',
-        'apollo-cache-inmemory',
-        'apollo-client',
-        'apollo-link',
-        'apollo-link-context',
-        'apollo-link-http',
-        'graphql',
-        'graphql-tools',
-        'graphql-tag'
-      ]
-    });
+      expose: [...defaultOptions, ...userOptions],
+    })
   },
 
   setupPreprocessorRegistry(type, registry) {
@@ -35,10 +40,10 @@ module.exports = {
         name: 'ember-apollo-client',
         ext: 'graphql',
         toTree(tree) {
-          const GraphQLFilter = require('./lib/graphql-filter');
-          return new GraphQLFilter(tree);
-        }
-      });
+          const GraphQLFilter = require('./lib/graphql-filter')
+          return new GraphQLFilter(tree)
+        },
+      })
     }
-  }
-};
+  },
+}

--- a/index.js
+++ b/index.js
@@ -26,7 +26,10 @@ module.exports = {
   treeForVendor() {
     const WebpackDependencyPlugin = require("./lib/webpack-dependency-plugin");
     const {
-      addonConfig: { include: userPackages, exclude: excludedPackages }
+      addonConfig: {
+        include: userPackages = [],
+        exclude: excludedPackages = []
+      }
     } = this;
     const includedPackages = apolloClientDefaultPackages.filter(
       p => !excludedPackages.includes(p)

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const defaultOptions = [
+const defaultPackages = [
   'apollo-cache',
   'apollo-cache-inmemory',
   'apollo-client',
@@ -17,24 +17,24 @@ module.exports = {
 
   included(app) {
     this._super.included.apply(this, arguments)
-
+    
     let config = app.project.config(app.env) || {}
-    this.addonConfig = config[this.name] || {}
-
+    this.addonConfig = config['apollo'] || {}
+    
     this.import('vendor/-apollo-client-bundle.js')
     this.import('vendor/-apollo-client-shims.js')
   },
-
+  
   treeForVendor() {
     const WebpackDependencyPlugin = require('./lib/webpack-dependency-plugin')
-    const userOptions = this.addonConfig.include
-
+    const userSpecifiedPackages = this.addonConfig.include
+    
     return new WebpackDependencyPlugin({
       outputName: 'apollo-client',
-      expose: [...defaultOptions, ...userOptions],
+      expose: [...defaultPackages, ...userSpecifiedPackages],
     })
   },
-
+  
   setupPreprocessorRegistry(type, registry) {
     if (type === 'parent') {
       registry.add('js', {

--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ module.exports = {
   included(app) {
     this._super.included.apply(this, arguments)
 
-    this.options['ember-apollo-client'] = app.options['ember-apollo-client']
+    let config = app.project.config(app.env) || {}
+    this.addonConfig = config[this.name] || {}
 
     this.import('vendor/-apollo-client-bundle.js')
     this.import('vendor/-apollo-client-shims.js')
@@ -26,7 +27,7 @@ module.exports = {
 
   treeForVendor() {
     const WebpackDependencyPlugin = require('./lib/webpack-dependency-plugin')
-    const userOptions = this.options['ember-apollo-client'].include
+    const userOptions = this.addonConfig.include
 
     return new WebpackDependencyPlugin({
       outputName: 'apollo-client',

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "repository": "https://github.com/bgentry/ember-apollo-client",
   "scripts": {
     "build": "ember build",
-    "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests",
+    "lint:js":
+      "eslint ./*.js addon addon-test-support app config lib server test-support tests",
     "start": "ember serve",
     "test": "ember try:each"
   },
@@ -68,7 +69,7 @@
     "loader.js": "^4.2.3"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "6.* || >= 7.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This in response to https://github.com/bgentry/ember-apollo-client/issues/108.

This *almost* works - one problem is that I also need to explicitly install whatever extra packages I've specifed, for example, if `config/environment.js` looks like:

```
apollo: {
  ...
  include: ['apollo-link-batch-http', 'apollo-link-persisted-queries'],
}

```

My app complains about missing modules unless I do
```
$ npm i --save-dev apollo-link-batch-http apollo-link-persisted-queries
```

So far I haven't figured out how to include these in an additional blueprint... any ideas? 