### PR TITLE
Replace all instances of copy with copyWithExtras

### DIFF
--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 import Service from "@ember/service"
 import EmberObject, { get, setProperties, computed } from "@ember/object";
 import { A } from "@ember/array";
-import { copy } from "@ember/object/internals";
 import { deprecate } from "@ember/application/deprecations";
 import { isArray } from "@ember/array";
 import { isNone, isPresent } from "@ember/utils";
@@ -151,7 +150,7 @@ export default Service.extend({
             let dataToSend = isNone(resultKey)
               ? result.data
               : get(result.data, resultKey);
-            dataToSend = copy(dataToSend, true);
+            dataToSend = copyWithExtras(dataToSend, [], []);
             return resolve(dataToSend);
           })
           .catch(error => {
@@ -227,7 +226,7 @@ export default Service.extend({
         if (!isNone(resultKey)) {
           response = get(response, resultKey);
         }
-        return RSVP.resolve(copy(response, true));
+        return RSVP.resolve(copyWithExtras(response, [], []));
       })
     );
   },

--- a/tests/unit/build/test-mutation.graphql
+++ b/tests/unit/build/test-mutation.graphql
@@ -1,0 +1,7 @@
+#import './test-fragment'
+
+mutation TestMutation($id: ID!) {
+  subject_update(id: $id) {
+    ...testFragment
+  }
+}

--- a/tests/unit/services/apollo-test.js
+++ b/tests/unit/services/apollo-test.js
@@ -2,6 +2,9 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { computed } from '@ember/object';
 import ApolloService from 'ember-apollo-client/services/apollo';
+import testQuery from '../build/test-query';
+import testMutation from '../build/test-mutation';
+import { Promise } from 'rsvp';
 
 module('Unit | Service | apollo', function(hooks) {
   setupTest(hooks);
@@ -28,5 +31,45 @@ module('Unit | Service | apollo', function(hooks) {
 
     // make sure the override was used.
     assert.equal(service.get('apollo.dataIdFromObject', customDataIdFromObject));
+  });
+
+  test('.mutate resolves with __typename', async function(assert) {
+    let done = assert.async();
+    let service = this.owner.lookup('service:apollo')
+
+    service.set('client', {
+      mutate() {
+        assert.ok(true, 'Called mutate function on apollo client');
+
+        return new Promise(resolve => {
+          resolve({ data: { human: { name: 'Link' },  __typename: 'person' } });
+        });
+      }
+    });
+
+    const result = await service.mutate({ mutation: testMutation });
+
+    assert.equal(result.__typename, 'person');
+    done();
+  });
+
+  test('.query resolves with __typename', async function(assert) {
+    let done = assert.async();
+    let service = this.owner.lookup('service:apollo')
+
+    service.set('client', {
+      query() {
+        assert.ok(true, 'Called query function on apollo client');
+
+        return new Promise(resolve => {
+          resolve({ data: { human: { name: 'Link' },  __typename: 'person' } });
+        });
+      }
+    });
+
+    const result = await service.query({ query: testQuery });
+
+    assert.equal(result.__typename, 'person');
+    done();
   });
 });

--- a/tests/unit/utils/copy-with-extras-test.js
+++ b/tests/unit/utils/copy-with-extras-test.js
@@ -1,0 +1,34 @@
+import copyWithExtras from 'ember-apollo-client/utils/copy-with-extras';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | copyWithExtras', function() {
+  test('copies all properties and extraCopyProperties', function(assert) {
+    const toCopy = {
+      foo: 'bar',
+      hamsters: ['Tomster', 'Zoey'],
+      people: [
+        { name: 'Link', __typename: 'hero' },
+        { name: 'Zelda', __typename: 'princess' }
+      ],
+      bestDay: new Date(2018, 3, 3),
+      todoCount: 4,
+      __typename: 'testData'
+    };
+
+    let result = copyWithExtras(toCopy, [], []);
+
+    assert.deepEqual(result, toCopy);
+  });
+
+  test('does not copy attributes prefixed with __ unless in extraCopyProperties', function(assert) {
+    const toCopy = {
+      __typename: 'test',
+      __otherAttribute: 'notATest'
+    };
+
+    let result = copyWithExtras(toCopy, [], []);
+
+    assert.equal(result.__typename, 'test');
+    assert.equal(result.__otherAttribute, undefined);
+  });
+});


### PR DESCRIPTION
`.mutate` and `.query` were still using `Ember.copy` so we weren't getting `__typename` in the resolved data :(

Also adds a unit test for the `copyWithExtras` utility.

Fixes https://github.com/bgentry/ember-apollo-client/issues/110