### PR TITLE
Make sure to run before ember-cli-babel (again)

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "node": "6.* || >= 7.*"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "before": ["ember-cli-babel"]
   }
 }


### PR DESCRIPTION
See #71 for the original context — it looks like this got undone in https://github.com/bgentry/ember-apollo-client/commit/2d9c0b7751e61cb1fda55f044dbf9e2d241fa2d6#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L61