### PR TITLE
upgrade graphql dependency to v0.13.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "broccoli-merge-trees": "^1.2.1",
     "broccoli-plugin": "^1.3.0",
     "ember-cli-babel": "^6.11.0",
-    "graphql": "^0.11.3",
+    "graphql": "^0.13.2",
     "graphql-tag": "^2.6.1",
     "graphql-tools": "^2.14.1",
     "webpack": "^2.2.1"

--- a/tests/unit/build/graphql-filter-test.js
+++ b/tests/unit/build/graphql-filter-test.js
@@ -5,16 +5,24 @@ import testFragment from './test-fragment';
 import testQuery from './test-query';
 
 module('Unit | graphql-filter', function() {
-  test('simple compilation', function(assert) {
-    assert.deepEqual(testFragment.definitions, gql`
+  function testCompilation(description, { actual, expected }) {
+    test(description, function(assert) {
+      assert.deepEqual(actual.definitions, JSON.parse(JSON.stringify(expected.definitions)));
+    });
+  }
+
+  testCompilation('simple compilation', {
+    actual: testFragment,
+    expected: gql`
       fragment testFragment on Object {
         name
       }
-    `.definitions);
+    `
   });
 
-  test('compilation with #import references', function(assert) {
-    assert.deepEqual(testQuery.definitions, gql`
+  testCompilation('compilation with #import references', {
+    actual: testQuery,
+    expected: gql`
       query TestQuery {
         subject {
           ...testFragment
@@ -24,6 +32,6 @@ module('Unit | graphql-filter', function() {
       fragment testFragment on Object {
         name
       }
-    `.definitions);
+    `
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3495,11 +3495,11 @@ graphql-tools@^2.14.1:
     iterall "^1.1.3"
     uuid "^3.1.0"
 
-graphql@^0.11.3:
-  version "0.11.7"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.11.7.tgz#e5abaa9cb7b7cccb84e9f0836bf4370d268750c6"
+graphql@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
   dependencies:
-    iterall "1.1.3"
+    iterall "^1.2.1"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -4115,11 +4115,7 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
-iterall@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.3.tgz#1cbbff96204056dde6656e2ed2e2226d0e6d72c9"
-
-iterall@^1.1.3:
+iterall@^1.1.3, iterall@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
 


### PR DESCRIPTION
This is breaking due to a small difference in the expected output and the actual output. Specifically, these two fields show up in the output directly from the graphql-tag but do not show up in the actual compiled filter output:

```json
          "alias": undefined,
          "selectionSet": undefined
```