### PR TITLE
Update README.md to update references from `this.apollo` to `this.get('apollo')`

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ import query from "my-app/gql/queries/human";
 export default Route.extend(RouteQueryManager, {
   model(params) {
     let variables = { id: params.id };
-    return this.apollo.watchQuery({ query, variables }, "human");
+    return this.get('apollo').watchQuery({ query, variables }, "human");
   }
 });
 ```
@@ -169,7 +169,7 @@ import { getObservable } from "ember-apollo-client";
 
 export default Route.extend(RouteQueryManager, {
   model() {
-    let result = this.apollo.watchQuery(...);
+    let result = this.get('apollo').watchQuery(...);
     let observable = getObservable(result);
     observable.fetchMore(...) // utilize the ObservableQuery
     ...


### PR DESCRIPTION
I was trying (maybe too insistently) to use `this.apollo` and then found this [comment](https://github.com/bgentry/ember-apollo-client/issues/112#issuecomment-376715527). Maybe this slight documentation tweak will help others.