### PR TITLE
Add acceptance test for watch query changed via mutation

### DIFF
--- a/tests/acceptance/watch-query-test.js
+++ b/tests/acceptance/watch-query-test.js
@@ -30,8 +30,8 @@ module('Acceptance | watch query', function(hooks) {
       },
       Mutation: {
         changeCharacterName(_, { id, name }) {
-          assert.equal(id, mockHuman.id, 'correct mutuation id is passed in');
-          assert.equal(name, 'Darth Vader', 'correct mutuation name is passed in');
+          assert.equal(id, mockHuman.id, 'correct mutation id is passed in');
+          assert.equal(name, 'Darth Vader', 'correct mutation name is passed in');
           return Object.assign({}, character, { name });
         }
       },

--- a/tests/acceptance/watch-query-test.js
+++ b/tests/acceptance/watch-query-test.js
@@ -1,0 +1,57 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from "dummy/tests/helpers/setup";
+import { addResolveFunctionsToSchema } from 'graphql-tools';
+import { click, currentURL, find, visit } from "@ember/test-helpers";
+
+const mockHuman = {
+  id: '1000',
+  name: 'Anakin Skywalker',
+  __typename: 'Human',
+};
+
+module('Acceptance | watch query', function(hooks) {
+  setupApplicationTest(hooks);
+
+  let schema;
+
+  hooks.beforeEach(function() {
+    schema = this.pretender.schema;
+  });
+
+  test('visiting /anakin', async function(assert) {
+    let done = assert.async();
+    let character = Object.assign({}, mockHuman);
+    let resolvers = {
+      Query: {
+        human(obj, args) {
+          assert.deepEqual(args, { id: '1000' });
+          return Object.assign({}, character);
+        },
+      },
+      Mutation: {
+        changeCharacterName(_, { id, name }) {
+          assert.equal(id, mockHuman.id, 'correct mutuation id is passed in');
+          assert.equal(name, 'Darth Vader', 'correct mutuation name is passed in');
+          return Object.assign({}, character, { name });
+        }
+      },
+      Character: {
+        __resolveType(obj) {
+          // Character interface needs to resolve to a specific type
+          // so it's just pulled from the object's type that was queried
+          return obj.__typename;
+        }
+      }
+    };
+
+    addResolveFunctionsToSchema({ schema, resolvers });
+
+    await visit('/anakin');
+    assert.equal(currentURL(), '/anakin');
+
+    assert.equal(find('.model-name').innerText, 'Anakin Skywalker', 'has correct name from initial query');
+    await click('.change-name');
+    assert.equal(find('.model-name').innerText, 'Darth Vader', 'has updated name from mutation and watch query');
+    done();
+  });
+});

--- a/tests/dummy/app/gql/mutations/change-character-name.graphql
+++ b/tests/dummy/app/gql/mutations/change-character-name.graphql
@@ -1,0 +1,6 @@
+mutation ChangeCharacterName($id: ID!, $name: String!) {
+  changeCharacterName(id: $id, name: $name) {
+    id
+    name
+  }
+}

--- a/tests/dummy/app/gql/queries/human.graphql
+++ b/tests/dummy/app/gql/queries/human.graphql
@@ -1,5 +1,6 @@
 query human($id: ID!) {
   human(id: $id) {
+    id
     name
   }
 }

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -9,6 +9,7 @@ const Router = EmberRouter.extend({
 Router.map(function() {
   this.route('characters');
   this.route('luke');
+  this.route('anakin');
   this.route('new-review');
 });
 

--- a/tests/dummy/app/routes/anakin.js
+++ b/tests/dummy/app/routes/anakin.js
@@ -1,0 +1,25 @@
+import Route from '@ember/routing/route';
+import RouteQueryManager from 'ember-apollo-client/mixins/route-query-manager';
+import query from 'dummy/gql/queries/human';
+import mutation from 'dummy/gql/mutations/change-character-name';
+
+const variables = { id: '1000' };
+
+export default Route.extend(RouteQueryManager, {
+  model() {
+    return this.get('apollo').watchQuery({
+      query,
+      variables,
+      fetchPolicy: 'cache-and-network',
+    }, 'human');
+  },
+
+  actions: {
+    changeName(id, name) {
+      return this.get('apollo').mutate({
+        mutation,
+        variables: { id, name }
+      });
+    }
+  },
+});

--- a/tests/dummy/app/templates/anakin.hbs
+++ b/tests/dummy/app/templates/anakin.hbs
@@ -1,0 +1,3 @@
+<div class='model-name'>{{model.name}}</div>
+
+<button {{action 'changeName' model.id 'Darth Vader'}} class="change-name">Change the name</button>

--- a/tests/fixtures/test-schema.graphql
+++ b/tests/fixtures/test-schema.graphql
@@ -23,6 +23,7 @@ type Query {
 # The mutation type, represents all updates we can make to our data
 type Mutation {
   createReview(episode: Episode, review: ReviewInput!): Review
+  changeCharacterName(id: ID!, name: String!): Character
 }
 
 # The episodes in the Star Wars trilogy


### PR DESCRIPTION
I wrote a test to better understand how `watchQuery` should work if a mutation is performed. Maybe it's valuable to be added to the test suite? I could refactor it into a route unit test, too. Cheers ✌🏽