### PR TITLE
Wrap query promise with RSVP promise

### DIFF
--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -221,12 +221,19 @@ export default Service.extend({
    */
   query(opts, resultKey) {
     return this._waitFor(
-      this.client.query(opts).then(result => {
-        let response = result.data;
-        if (!isNone(resultKey)) {
-          response = get(response, resultKey);
-        }
-        return RSVP.resolve(copyWithExtras(response, [], []));
+      new RSVP.Promise((resolve, reject) => {
+        this.client
+          .query(opts)
+          .then(result => {
+            let response = result.data;
+            if (!isNone(resultKey)) {
+              response = get(response, resultKey);
+            }
+            return resolve(copyWithExtras(response, [], []));
+          })
+          .catch(error => {
+            return reject(error);
+          });
       })
     );
   },


### PR DESCRIPTION
When using `apollo.query(...` directly (no `watchQuery`), if there is an error from the API that causes the promise to be rejected, the apollo service would throw an error `promise.finally is not a function`. 

The problem is that `query` was returning a native promise, which does not have the method `finally`, others function are wrapped with a RSVP promise but not the`query`.

Unfortunately, I wasn't able to reproduce the problem in the test env to be able to write a test case for this. Open to suggestions.