### PR TITLE
fix: Allows ember-engines to read apollo config from host's `options`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,9 @@ module.exports = {
 
   included() {
     this._super.included.apply(this, arguments);
-    this.addonConfig = this.app.options['apollo'] || {};
+
+    const host = this._findHost();
+    this.addonConfig = host.options['apollo'] || {};
 
     this.import('vendor/-apollo-client-bundle.js');
     this.import('vendor/-apollo-client-shims.js');


### PR DESCRIPTION
`this.app` is undefined in the context of an ember-engine.  This fix uses the `_findHost()` API for discovering the host app (previously the same object as `this.app`).

Yes, `_findHost()` is a private API but it's commonly used across the ecosystem for this purpose.  If you want, I can replicate it with a while loop walking the parent hierarchy to achieve the same thing.

This is PR 1 of 2 that fixes ember-apollo-client with ember-engines.  The next PR will resolve Webpack looking for the apollo libs in the wrong place.

Related to #152

