### PR TITLE
add shorter mixin import paths, use from tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ mixin and `watchQuery`:
 
 ```js
 import Route from "@ember/routing/route";
-import RouteQueryManager from "ember-apollo-client/mixins/route-query-manager";
+import { RouteQueryManager } from "ember-apollo-client";
 import query from "my-app/gql/queries/human";
 
 export default Route.extend(RouteQueryManager, {
@@ -377,7 +377,8 @@ whenever the store is updated with new data about the resolved objects. This
 happens until you explicitly unsubscribe from it.
 
 In ember-apollo-client, most unsubscriptions are handled automatically by the
-`RouteQueryManager`, `ObjectQueryManager` and `ComponentQueryManager` mixins, so long as you use them.
+`RouteQueryManager`, `ObjectQueryManager` and `ComponentQueryManager` mixins,
+so long as you use them.
 
 If you're fetching data elsewhere, such as in an Ember Service, or if you use
 the Apollo service directly, you are responsible for unsubscribing from
@@ -394,7 +395,7 @@ a base route class:
 
 ```js
 import Route from "@ember/routing/route";
-import RouteQueryManager from "ember-apollo-client/mixins/route-query-manager";
+import { RouteQueryManager } from "ember-apollo-client";
 
 export default Route.extend(RouteQueryManager);
 ```

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,5 +1,11 @@
+import ComponentQueryManager from 'ember-apollo-client/mixins/component-query-manager';
+import ObjectQueryManager from 'ember-apollo-client/mixins/object-query-manager';
+import RouteQueryManager from 'ember-apollo-client/mixins/route-query-manager';
+
 export function getObservable(queryResult) {
   return queryResult._apolloObservable;
 }
 
 export let apolloObservableKey = '_apolloObservable';
+
+export { ComponentQueryManager, ObjectQueryManager, RouteQueryManager };

--- a/tests/dummy/app/routes/anakin.js
+++ b/tests/dummy/app/routes/anakin.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import RouteQueryManager from 'ember-apollo-client/mixins/route-query-manager';
+import { RouteQueryManager } from 'ember-apollo-client';
 import query from 'dummy/gql/queries/human';
 import mutation from 'dummy/gql/mutations/change-character-name';
 

--- a/tests/dummy/app/routes/characters.js
+++ b/tests/dummy/app/routes/characters.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import RouteQueryManager from 'ember-apollo-client/mixins/route-query-manager';
+import { RouteQueryManager } from 'ember-apollo-client';
 import query from 'dummy/gql/queries/characters';
 
 export default Route.extend(RouteQueryManager, {

--- a/tests/dummy/app/routes/luke.js
+++ b/tests/dummy/app/routes/luke.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import RouteQueryManager from 'ember-apollo-client/mixins/route-query-manager';
+import { RouteQueryManager } from 'ember-apollo-client';
 import query from 'dummy/gql/queries/human';
 
 const variables = { id: '1000' };

--- a/tests/unit/mixins/component-query-manager-test.js
+++ b/tests/unit/mixins/component-query-manager-test.js
@@ -1,5 +1,5 @@
 import EmberObject from '@ember/object';
-import ComponentQueryManagerMixin from 'ember-apollo-client/mixins/component-query-manager';
+import { ComponentQueryManager } from 'ember-apollo-client';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
@@ -8,7 +8,7 @@ module('Unit | Mixin | component query manager', function(hooks) {
 
   hooks.beforeEach(function() {
     this.subject = function() {
-      let TestObject = EmberObject.extend(ComponentQueryManagerMixin);
+      let TestObject = EmberObject.extend(ComponentQueryManager);
       this.owner.register('test-container:test-object', TestObject);
       return this.owner.lookup('test-container:test-object');
     };

--- a/tests/unit/mixins/object-query-manager-test.js
+++ b/tests/unit/mixins/object-query-manager-test.js
@@ -1,5 +1,5 @@
 import EmberObject from '@ember/object';
-import ObjectQueryManagerMixin from 'ember-apollo-client/mixins/object-query-manager';
+import { ObjectQueryManager } from 'ember-apollo-client';
 import { ApolloClient } from 'apollo-client';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
@@ -9,7 +9,7 @@ module('Unit | Mixin | ember object query manager', function(hooks) {
 
   hooks.beforeEach(function() {
     this.subject = function() {
-      let TestObject = EmberObject.extend(ObjectQueryManagerMixin);
+      let TestObject = EmberObject.extend(ObjectQueryManager);
       this.owner.register('test-container:test-object', TestObject);
       return this.owner.lookup('test-container:test-object');
     };

--- a/tests/unit/mixins/route-query-manager-test.js
+++ b/tests/unit/mixins/route-query-manager-test.js
@@ -1,5 +1,5 @@
 import EmberObject from '@ember/object';
-import RouteQueryManagerMixin from 'ember-apollo-client/mixins/route-query-manager';
+import { RouteQueryManager } from 'ember-apollo-client';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
@@ -8,7 +8,7 @@ module('Unit | Mixin | route query manager', function(hooks) {
 
   hooks.beforeEach(function() {
     this.subject = function() {
-      let TestObject = EmberObject.extend(RouteQueryManagerMixin);
+      let TestObject = EmberObject.extend(RouteQueryManager);
       this.owner.register('test-container:test-object', TestObject);
       return this.owner.lookup('test-container:test-object');
     };


### PR DESCRIPTION
This is a partial fix for #156. It adds new exports for the query manager mixins, which can be imported like so:

```js
// routes:
import { RouteQueryManager } from "ember-apollo-client";

export default Component.extend(RouteQueryManager, {
  ...
});

// components:
import { ComponentQueryManager } from "ember-apollo-client";

export default Component.extend(ComponentQueryManager, {
  ...
});

// objects:
import { ObjectQueryManager } from "ember-apollo-client";

export default Component.extend(ObjectQueryManager, {
  ...
});
```

I've also updated the readme to reflect these new imports, and updated the tests + dummy app to use them.

The part of #156 which is not included is a deprecation of the old mixin import paths (i.e. `ember-apollo-client/mixins/*-query-manager`). I'm actually not certain about how to do this correctly. I'd appreciate some guidance if anybody can point me at a similar example 😄