### PR TITLE
revert graphql-tools restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ember-cli-babel": "^6.11.0",
     "graphql": "^0.13.2",
     "graphql-tag": "^2.6.1",
-    "graphql-tools": ">2.14.1 <3.1.0",
+    "graphql-tools": ">2.14.1",
     "webpack": "^2.2.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -257,7 +257,7 @@ apollo-link-http@^1.3.2:
     apollo-link "^1.2.2"
     apollo-link-http-common "^0.2.4"
 
-apollo-link@1.2.2, apollo-link@^1.0.0, apollo-link@^1.0.7, apollo-link@^1.2.2:
+apollo-link@^1.0.0, apollo-link@^1.0.7, apollo-link@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.2.tgz#54c84199b18ac1af8d63553a68ca389c05217a03"
   dependencies:
@@ -3608,11 +3608,11 @@ graphql-tag@^2.6.1, graphql-tag@^2.8.0:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.9.2.tgz#2f60a5a981375f430bf1e6e95992427dc18af686"
 
-"graphql-tools@>2.14.1 <3.1.0":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-3.0.5.tgz#544542dbf2fddc8c3d7d654965285a3bc747b10b"
+graphql-tools@>2.14.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-3.1.1.tgz#d593358f01e7c8b1671a17b70ddb034dea9dbc50"
   dependencies:
-    apollo-link "1.2.2"
+    apollo-link "^1.2.2"
     apollo-utilities "^1.0.1"
     deprecated-decorator "^0.1.6"
     iterall "^1.1.3"


### PR DESCRIPTION
The breaking change in graphql-tools has been reverted, so the latest release is ok now https://github.com/apollographql/graphql-tools/issues/915