### PR TITLE
fetch addon config lazily

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,11 +18,12 @@ module.exports = {
   included() {
     this._super.included.apply(this, arguments);
 
-    const host = this._findHost();
-    this.addonConfig = host.options['apollo'] || {};
-
     this.import('vendor/-apollo-client-bundle.js');
     this.import('vendor/-apollo-client-shims.js');
+  },
+
+  addonConfig() {
+    return this._findHost().options['apollo'] || {};
   },
 
   treeForVendor() {
@@ -30,7 +31,7 @@ module.exports = {
     const {
       include: userPackages = [],
       exclude: excludedPackages = [],
-    } = this.addonConfig;
+    } = this.addonConfig();
 
     const includedPackages = apolloClientDefaultPackages.filter(
       p => !excludedPackages.includes(p)


### PR DESCRIPTION
It's a somewhat common practice for one addon to augment another addon's config. One example is ember-decorators, which adds babel plugins to ember-cli-babel's config.

For my use case: I'm using ember-apollo-client in an application with several engines. I'm creating the client in the host application and injecting it into the individual engines (partly because of #152, but I think this structure generally make sense). To make testing each engine easier, I'm wrapping ember-apollo-client with an addon that preconfigures the client. I then install my wrapper addon into the "dummy" app for each engine.

Before this change, ember-apollo-client caches its config (in `included()`) before my wrapper addon has a chance to mutate it.