### PR TITLE
fix: gracefully handle null/undefined with watchQuery(..., resultKey)

### DIFF
--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -32,8 +32,8 @@ function newDataFunc(observable, resultKey, resolve, mergedProps = {}) {
       // See https://github.com/bgentry/ember-apollo-client/issues/45
       return;
     }
-    let keyedData = isNone(resultKey) ? data : get(data, resultKey);
-    let dataToSend = copyWithExtras(keyedData, [], []);
+    let keyedData = isNone(resultKey) ? data : data && get(data, resultKey);
+    let dataToSend = copyWithExtras(keyedData || {}, [], []);
     if (isNone(obj)) {
       if (isArray(dataToSend)) {
         obj = A(dataToSend);

--- a/tests/unit/services/apollo-test.js
+++ b/tests/unit/services/apollo-test.js
@@ -77,4 +77,40 @@ module('Unit | Service | apollo', function(hooks) {
     assert.equal(result.__typename, 'person');
     done();
   });
+
+  test('.watchQuery with key', async function(assert) {
+    let service = this.owner.lookup('service:apollo');
+
+    service.set('client', {
+      watchQuery() {
+        assert.ok(true, 'Called watchQuery function on apollo client');
+
+        return {
+          subscribe({ next }) {
+            next({ data: { human: { name: 'Link' }, __typename: 'person' } });
+          },
+        };
+      },
+    });
+
+    const result = await service.watchQuery({ query: testQuery }, 'human');
+    assert.equal(result.get('name'), 'Link');
+  });
+
+  test('.watchQuery with key gracefully handles null', async function(assert) {
+    let service = this.owner.lookup('service:apollo');
+
+    service.set('client', {
+      watchQuery() {
+        return {
+          subscribe({ next }) {
+            next({ data: null });
+          },
+        };
+      },
+    });
+
+    const result = await service.watchQuery({ query: testQuery }, 'human');
+    assert.equal(result.get('name'), undefined);
+  });
 });


### PR DESCRIPTION
If the server returns `{ data: null, errors: [] }` *and* you supply a `resultKey` argument to watchQuery, you'll get an error in `newDataFunc`.