### PR TITLE
Feature/subscription support

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,10 +201,13 @@ import { RouteQueryManager } from "ember-apollo-client";
 import query from "my-app/gql/subscription/new-human";
 
 export default Route.extend(RouteQueryManager, {
-  setupSubscription() {
-    this.get("apollo")
-        .subscribe({ query }, "human");
-        .on("event", event => alert(`${event.name} was just born!`));
+  model() {
+    return this.get("apollo")
+               .subscribe({ query }, "human");
+  },
+
+  setupController(controller, model) {
+    model.on("event", event => alert(`${event.name} was just born!`));
   },
 });
 ```

--- a/README.md
+++ b/README.md
@@ -198,12 +198,12 @@ subscription {
 ```js
 import Route from "@ember/routing/route";
 import { RouteQueryManager } from "ember-apollo-client";
-import subscription from "my-app/gql/subscription/new-human";
+import query from "my-app/gql/subscription/new-human";
 
 export default Route.extend(RouteQueryManager, {
   setupSubscription() {
     this.get("apollo")
-        .subscribe({ subscription }, "human");
+        .subscribe({ query }, "human");
         .on("event", event => alert(`${event.name} was just born!`));
   },
 });

--- a/README.md
+++ b/README.md
@@ -175,15 +175,15 @@ the service directly.
 
 GQL Subscriptions allow a client to subscribe to specific queries they are interested in tracking. The syntax for doing this is similar to `query` / `watchQuery`, but there are a few main differences:
 
-- ) you must define a `subscription` (versus a `query` or `mutation`)
-- ) because subscriptions are async by nature, you have to listen for these events and act accordingly.
-- ) subscriptions require websockets, so must configure your `link` accordingly
+- you must define a `subscription` (versus a `query` or `mutation`)
+- because subscriptions are async by nature, you have to listen for these events and act accordingly.
+- subscriptions require websockets, so must configure your `link` accordingly
 
-**Creating your subscription:**
+#### Creating your subscription
 
 `my-app/gql/subscription/new-human`
 
-```
+```graphql
 subscription {
   newHuman() {
     name
@@ -191,7 +191,7 @@ subscription {
 }
 ```
 
-**Subscribing from inside a route:**
+#### Subscribing from inside a route
 
 `app/routes/some-route.js`
 
@@ -212,7 +212,7 @@ export default Route.extend(RouteQueryManager, {
 });
 ```
 
-The big advantage of using the RouteQueryManager is that when you navigate away from this route, all subscriptions created will be terminated. That said, if you want to manually unsubscribe (or are not using the RouteQueryManager) `subscription.unsubscribe()` will do the trick.
+The big advantage of using the `RouteQueryManager` is that when you navigate away from this route, all subscriptions created will be terminated. That said, if you want to manually unsubscribe (or are not using the `RouteQueryManager`) `subscription.unsubscribe()` will do the trick.
 
 **Enabling Websockets**
 
@@ -254,9 +254,9 @@ import { createAbsintheSocketLink } from '@absinthe/socket-apollo-link';
 import AbsintheSocket from '@absinthe/socket';
 
 export default ApolloService.extend({
-  session      : service(),
+  session: service(),
 
-link: computed(function () {
+  link: computed(function () {
     const httpLink = this._super(...arguments);
     const socket = new Socket("ws://socket-url", {
       params: { token: this.get('session.token') },
@@ -273,8 +273,8 @@ link: computed(function () {
       httpLink
     );
   }),
-
 ```
+
 
 ### Mutations and Fragments
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ GQL Subscriptions allow a client to subscribe to specific queries they are inter
 
 #### Creating your subscription
 
-`my-app/gql/subscription/new-human`
+`app/gql/subscriptions/new-human.graphql`
 
 ```graphql
 subscription {
@@ -196,18 +196,18 @@ subscription {
 `app/routes/some-route.js`
 
 ```js
-import Route from "@ember/routing/route";
-import { RouteQueryManager } from "ember-apollo-client";
-import query from "my-app/gql/subscription/new-human";
+import Route from '@ember/routing/route';
+import { RouteQueryManager } from 'ember-apollo-client';
+import query from 'app/gql/subscriptions/new-human';
 
 export default Route.extend(RouteQueryManager, {
   model() {
-    return this.get("apollo")
-               .subscribe({ query }, "human");
+    return this.get('apollo')
+               .subscribe({ query }, 'human');
   },
 
   setupController(controller, model) {
-    model.on("event", event => alert(`${event.name} was just born!`));
+    model.on('event', event => alert(`${event.name} was just born!`));
   },
 });
 ```

--- a/addon/-private/mixins/base-query-manager.js
+++ b/addon/-private/mixins/base-query-manager.js
@@ -1,10 +1,10 @@
 import { inject as service } from '@ember/service';
 import Mixin from '@ember/object/mixin';
+import { computed } from '@ember/object';
 
 export default Mixin.create({
   apolloService: service('apollo'),
-  init() {
-    this._super(...arguments);
-    this.set('apollo', this.get('apolloService').createQueryManager());
-  },
+  apollo: computed('apolloService', function() {
+    return this.get('apolloService').createQueryManager();
+  }),
 });

--- a/addon/apollo/query-manager.js
+++ b/addon/apollo/query-manager.js
@@ -60,6 +60,10 @@ export default EmberObject.extend({
     return this.get('apollo').managedWatchQuery(this, opts, resultKey);
   },
 
+  subscribe(opts, resultKey) {
+    return this.get('apollo').managedSubscribe(this, opts, resultKey);
+  },
+
   /**
    * Tracks a subscription in the list of active subscriptions, which will all be
    * cancelled when `unsubcribeAll` is called.

--- a/addon/apollo/query-manager.js
+++ b/addon/apollo/query-manager.js
@@ -60,6 +60,21 @@ export default EmberObject.extend({
     return this.get('apollo').managedWatchQuery(this, opts, resultKey);
   },
 
+  /**
+   * Executes a `subscribe` on the Apollo service.
+   *
+   * This subscription is tracked by the QueryManager and will be unsubscribed
+   * (and no longer updated with new data) when unsubscribeAll() is called.
+   *
+   * The Promise will contain a Subscription object which will contain events
+   * as they come in. It will also trigger `event` messages which can be listened for.
+   *
+   * @method subscribe
+   * @param {!Object} opts The query options used in the Apollo Client watchQuery.
+   * @param {String} resultKey The key that will be returned from the resulting response data. If null or undefined, the entire response data will be returned.
+   * @return {!Promise}
+   * @public
+   */
   subscribe(opts, resultKey) {
     return this.get('apollo').managedSubscribe(this, opts, resultKey);
   },

--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -17,22 +17,55 @@ import QueryManager from 'ember-apollo-client/apollo/query-manager';
 import copyWithExtras from 'ember-apollo-client/utils/copy-with-extras';
 import { registerWaiter } from '@ember/test';
 import fetch from 'fetch';
+import Evented from '@ember/object/evented';
+
+const Subscription = EmberObject.extend(Evented, {
+  init(...args) {
+    this._super(...args);
+
+    this.set('events', []);
+  },
+
+  lastEvent: alias('events.firstObject'),
+
+  apolloUnsubscribe() {
+    this.get('_apolloClientSubscription').unsubscribe();
+  },
+
+  _apolloClientSubscription: null,
+
+  _onNewData(newData) {
+    this.get('events').unshiftObject(newData);
+    this.trigger('event', newData);
+  },
+});
+
+function extractNewData(resultKey, { data, loading }) {
+  if (loading && data === undefined) {
+    // This happens when the cache has no data and the data is still loading
+    // from the server. We don't want to resolve the promise with empty data
+    // so we instead just bail out.
+    //
+    // See https://github.com/bgentry/ember-apollo-client/issues/45
+    return null;
+  }
+  let keyedData = isNone(resultKey) ? data : data && get(data, resultKey);
+
+  return copyWithExtras(keyedData || {}, [], []);
+}
 
 function newDataFunc(observable, resultKey, resolve, mergedProps = {}) {
   let obj;
   mergedProps[apolloObservableKey] = observable;
 
-  return ({ data, loading }) => {
-    if (loading && data === undefined) {
-      // This happens when the cache has no data and the data is still loading
-      // from the server. We don't want to resolve the promise with empty data
-      // so we instead just bail out.
-      //
-      // See https://github.com/bgentry/ember-apollo-client/issues/45
+  return newData => {
+    let dataToSend = extractNewData(resultKey, newData);
+
+    if (dataToSend === null) {
+      // see comment in extractNewData
       return;
     }
-    let keyedData = isNone(resultKey) ? data : data && get(data, resultKey);
-    let dataToSend = copyWithExtras(keyedData || {}, [], []);
+
     if (isNone(obj)) {
       if (isArray(dataToSend)) {
         obj = A(dataToSend);
@@ -198,6 +231,50 @@ export default Service.extend({
   },
 
   /**
+   * Executes a `subscribe` on the Apollo client. If this subscription receives
+   * data, the resolved object will be updated with the new data.
+   *
+   * When using this method, it is important to call `apolloUnsubscribe()` on
+   * the resolved data when the route or component is torn down. That tells
+   * Apollo to stop trying to send updated data to a non-existent listener.
+   *
+   * @method subscribe
+   * @param {!Object} opts The query options used in the Apollo Client subscribe.
+   * @param {String} resultKey The key that will be returned from the resulting response data. If null or undefined, the entire response data will be returned.
+   * @return {!Promise}
+   * @public
+   */
+  subscribe(opts, resultKey = null) {
+    const observable = this.get('client').subscribe(opts);
+
+    const obj = Subscription.create();
+
+    return this._waitFor(
+      new RSVP.Promise((resolve, reject) => {
+        let subscription = observable.subscribe({
+          next: newData => {
+            let dataToSend = extractNewData(resultKey, newData);
+
+            if (dataToSend === null) {
+              // see comment in extractNewData
+              return;
+            }
+
+            run(() => obj._onNewData(dataToSend));
+          },
+          error(e) {
+            reject(e);
+          },
+        });
+
+        obj.set('_apolloClientSubscription', subscription);
+
+        resolve(obj);
+      })
+    );
+  },
+
+  /**
    * Executes a single `query` on the Apollo client. The resolved object will
    * never be updated and does not have to be unsubscribed.
    *
@@ -251,6 +328,25 @@ export default Service.extend({
         manager.trackSubscription(subscription);
       })
     );
+  },
+
+  /**
+   * Executes a `subscribe` on the Apollo client and tracks the resulting
+   * subscription on the provided query manager.
+   *
+   * @method managedSubscribe
+   * @param {!Object} manager A QueryManager that should track this active subscribe.
+   * @param {!Object} opts The query options used in the Apollo Client subscribe.
+   * @param {String} resultKey The key that will be returned from the resulting response data. If null or undefined, the entire response data will be returned.
+   * @return {!Promise}
+   * @private
+   */
+  managedSubscribe(manager, opts, resultKey = null) {
+    return this.subscribe(opts, resultKey).then(obj => {
+      manager.trackSubscription(obj._apolloClientSubscription);
+
+      return obj;
+    });
   },
 
   createQueryManager() {

--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -19,11 +19,10 @@ import { registerWaiter } from '@ember/test';
 import fetch from 'fetch';
 import Evented from '@ember/object/evented';
 
-const Subscription = EmberObject.extend(Evented, {
-  init(...args) {
-    this._super(...args);
-
-    this.set('events', []);
+const EmberApolloSubscription = EmberObject.extend(Evented, {
+  init() {
+    this._super(...arguments);
+    this.set('events', A([]));
   },
 
   lastEvent: alias('events.firstObject'),
@@ -41,7 +40,7 @@ const Subscription = EmberObject.extend(Evented, {
 });
 
 function extractNewData(resultKey, { data, loading }) {
-  if (loading && data === undefined) {
+  if (loading && isNone(data)) {
     // This happens when the cache has no data and the data is still loading
     // from the server. We don't want to resolve the promise with empty data
     // so we instead just bail out.
@@ -247,14 +246,13 @@ export default Service.extend({
   subscribe(opts, resultKey = null) {
     const observable = this.get('client').subscribe(opts);
 
-    const obj = Subscription.create();
+    const obj = EmberApolloSubscription.create();
 
     return this._waitFor(
       new RSVP.Promise((resolve, reject) => {
         let subscription = observable.subscribe({
           next: newData => {
             let dataToSend = extractNewData(resultKey, newData);
-
             if (dataToSend === null) {
               // see comment in extractNewData
               return;

--- a/addon/services/apollo.js
+++ b/addon/services/apollo.js
@@ -20,12 +20,7 @@ import fetch from 'fetch';
 import Evented from '@ember/object/evented';
 
 const EmberApolloSubscription = EmberObject.extend(Evented, {
-  init() {
-    this._super(...arguments);
-    this.set('events', A([]));
-  },
-
-  lastEvent: alias('events.firstObject'),
+  lastEvent: null,
 
   apolloUnsubscribe() {
     this.get('_apolloClientSubscription').unsubscribe();
@@ -34,7 +29,7 @@ const EmberApolloSubscription = EmberObject.extend(Evented, {
   _apolloClientSubscription: null,
 
   _onNewData(newData) {
-    this.get('events').unshiftObject(newData);
+    this.set('lastEvent', newData);
     this.trigger('event', newData);
   },
 });

--- a/tests/unit/build/graphql-filter-test.js
+++ b/tests/unit/build/graphql-filter-test.js
@@ -3,6 +3,7 @@ import gql from 'graphql-tag';
 
 import testFragment from './test-fragment';
 import testQuery from './test-query';
+import testSubscription from './test-subscription';
 
 module('Unit | graphql-filter', function() {
   function testCompilation(description, { actual, expected }) {
@@ -19,6 +20,17 @@ module('Unit | graphql-filter', function() {
     expected: gql`
       fragment testFragment on Object {
         name
+      }
+    `,
+  });
+
+  testCompilation('simple subscription compilation', {
+    actual: testSubscription,
+    expected: gql`
+      subscription TestSubscription {
+        subject {
+          name
+        }
       }
     `,
   });

--- a/tests/unit/build/test-subscription.graphql
+++ b/tests/unit/build/test-subscription.graphql
@@ -1,0 +1,5 @@
+subscription TestSubscription {
+  subject {
+    name
+  }
+}

--- a/tests/unit/mixins/component-query-manager-test.js
+++ b/tests/unit/mixins/component-query-manager-test.js
@@ -42,7 +42,7 @@ module('Unit | Mixin | component query manager', function(hooks) {
     done();
   });
 
-  test('it unsubscribes from any subscribe subscriptions', function(assert) {
+  test('it unsubscribes from any subscriptions', function(assert) {
     let done = assert.async();
     let subject = this.subject();
     let unsubscribeCalled = 0;

--- a/tests/unit/mixins/component-query-manager-test.js
+++ b/tests/unit/mixins/component-query-manager-test.js
@@ -49,7 +49,7 @@ module('Unit | Mixin | component query manager', function(hooks) {
 
     let apolloService = subject.get('apollo.apollo');
     apolloService.set('managedSubscribe', (manager, opts) => {
-      assert.deepEqual(opts, { subscription: 'fakeSubscription' });
+      assert.deepEqual(opts, { query: 'fakeSubscription' });
       manager.trackSubscription({
         unsubscribe() {
           unsubscribeCalled++;
@@ -58,8 +58,8 @@ module('Unit | Mixin | component query manager', function(hooks) {
       return {};
     });
 
-    subject.get('apollo').subscribe({ subscription: 'fakeSubscription' });
-    subject.get('apollo').subscribe({ subscription: 'fakeSubscription' });
+    subject.get('apollo').subscribe({ query: 'fakeSubscription' });
+    subject.get('apollo').subscribe({ query: 'fakeSubscription' });
 
     subject.willDestroyElement();
     assert.equal(

--- a/tests/unit/mixins/component-query-manager-test.js
+++ b/tests/unit/mixins/component-query-manager-test.js
@@ -41,4 +41,32 @@ module('Unit | Mixin | component query manager', function(hooks) {
     );
     done();
   });
+
+  test('it unsubscribes from any subscribe subscriptions', function(assert) {
+    let done = assert.async();
+    let subject = this.subject();
+    let unsubscribeCalled = 0;
+
+    let apolloService = subject.get('apollo.apollo');
+    apolloService.set('managedSubscribe', (manager, opts) => {
+      assert.deepEqual(opts, { subscription: 'fakeSubscription' });
+      manager.trackSubscription({
+        unsubscribe() {
+          unsubscribeCalled++;
+        },
+      });
+      return {};
+    });
+
+    subject.get('apollo').subscribe({ subscription: 'fakeSubscription' });
+    subject.get('apollo').subscribe({ subscription: 'fakeSubscription' });
+
+    subject.willDestroyElement();
+    assert.equal(
+      unsubscribeCalled,
+      2,
+      '_apolloUnsubscribe() was called once per subscribe'
+    );
+    done();
+  });
 });

--- a/tests/unit/mixins/object-query-manager-test.js
+++ b/tests/unit/mixins/object-query-manager-test.js
@@ -43,7 +43,7 @@ module('Unit | Mixin | ember object query manager', function(hooks) {
     done();
   });
 
-  test('it unsubscribes from any subscribe subscriptions', function(assert) {
+  test('it unsubscribes from any subscriptions', function(assert) {
     let done = assert.async();
     let subject = this.subject();
     let unsubscribeCalled = 0;

--- a/tests/unit/mixins/object-query-manager-test.js
+++ b/tests/unit/mixins/object-query-manager-test.js
@@ -43,6 +43,34 @@ module('Unit | Mixin | ember object query manager', function(hooks) {
     done();
   });
 
+  test('it unsubscribes from any subscribe subscriptions', function(assert) {
+    let done = assert.async();
+    let subject = this.subject();
+    let unsubscribeCalled = 0;
+
+    let apolloService = subject.get('apollo.apollo');
+    apolloService.set('managedSubscribe', (manager, opts) => {
+      assert.deepEqual(opts, { subscription: 'fakeSubscription' });
+      manager.trackSubscription({
+        unsubscribe() {
+          unsubscribeCalled++;
+        },
+      });
+      return {};
+    });
+
+    subject.get('apollo').subscribe({ subscription: 'fakeSubscription' });
+    subject.get('apollo').subscribe({ subscription: 'fakeSubscription' });
+
+    subject.willDestroy();
+    assert.equal(
+      unsubscribeCalled,
+      2,
+      '_apolloUnsubscribe() was called once per subscribe'
+    );
+    done();
+  });
+
   test('it exposes an apollo client object', function(assert) {
     let subject = this.subject();
     let client = subject.get('apollo.apolloClient');

--- a/tests/unit/mixins/object-query-manager-test.js
+++ b/tests/unit/mixins/object-query-manager-test.js
@@ -50,7 +50,7 @@ module('Unit | Mixin | ember object query manager', function(hooks) {
 
     let apolloService = subject.get('apollo.apollo');
     apolloService.set('managedSubscribe', (manager, opts) => {
-      assert.deepEqual(opts, { subscription: 'fakeSubscription' });
+      assert.deepEqual(opts, { query: 'fakeSubscription' });
       manager.trackSubscription({
         unsubscribe() {
           unsubscribeCalled++;
@@ -59,8 +59,8 @@ module('Unit | Mixin | ember object query manager', function(hooks) {
       return {};
     });
 
-    subject.get('apollo').subscribe({ subscription: 'fakeSubscription' });
-    subject.get('apollo').subscribe({ subscription: 'fakeSubscription' });
+    subject.get('apollo').subscribe({ query: 'fakeSubscription' });
+    subject.get('apollo').subscribe({ query: 'fakeSubscription' });
 
     subject.willDestroy();
     assert.equal(

--- a/tests/unit/mixins/route-query-manager-test.js
+++ b/tests/unit/mixins/route-query-manager-test.js
@@ -43,6 +43,35 @@ module('Unit | Mixin | route query manager', function(hooks) {
     done();
   });
 
+  test('it unsubscribes from any subscribe subscriptions', function(assert) {
+    let done = assert.async();
+    let subject = this.subject();
+    let unsubscribeCalled = 0;
+
+    let apolloService = subject.get('apollo.apollo');
+    apolloService.set('managedSubscribe', (manager, opts) => {
+      assert.deepEqual(opts, { subscription: 'fakeSubscription' });
+      manager.trackSubscription({
+        unsubscribe() {
+          unsubscribeCalled++;
+        },
+      });
+      return {};
+    });
+
+    subject.get('apollo').subscribe({ subscription: 'fakeSubscription' });
+    subject.get('apollo').subscribe({ subscription: 'fakeSubscription' });
+
+    subject.beforeModel();
+    subject.resetController({}, true);
+    assert.equal(
+      unsubscribeCalled,
+      2,
+      '_apolloUnsubscribe() was called once per subscribe'
+    );
+    done();
+  });
+
   test('it only unsubscribes from stale watchQuery subscriptions with isExiting=false', function(assert) {
     let done = assert.async();
     let subject = this.subject();

--- a/tests/unit/mixins/route-query-manager-test.js
+++ b/tests/unit/mixins/route-query-manager-test.js
@@ -50,7 +50,7 @@ module('Unit | Mixin | route query manager', function(hooks) {
 
     let apolloService = subject.get('apollo.apollo');
     apolloService.set('managedSubscribe', (manager, opts) => {
-      assert.deepEqual(opts, { subscription: 'fakeSubscription' });
+      assert.deepEqual(opts, { query: 'fakeSubscription' });
       manager.trackSubscription({
         unsubscribe() {
           unsubscribeCalled++;
@@ -59,8 +59,8 @@ module('Unit | Mixin | route query manager', function(hooks) {
       return {};
     });
 
-    subject.get('apollo').subscribe({ subscription: 'fakeSubscription' });
-    subject.get('apollo').subscribe({ subscription: 'fakeSubscription' });
+    subject.get('apollo').subscribe({ query: 'fakeSubscription' });
+    subject.get('apollo').subscribe({ query: 'fakeSubscription' });
 
     subject.beforeModel();
     subject.resetController({}, true);

--- a/tests/unit/mixins/route-query-manager-test.js
+++ b/tests/unit/mixins/route-query-manager-test.js
@@ -43,7 +43,7 @@ module('Unit | Mixin | route query manager', function(hooks) {
     done();
   });
 
-  test('it unsubscribes from any subscribe subscriptions', function(assert) {
+  test('it unsubscribes from any subscriptions', function(assert) {
     let done = assert.async();
     let subject = this.subject();
     let unsubscribeCalled = 0;

--- a/tests/unit/services/apollo-test.js
+++ b/tests/unit/services/apollo-test.js
@@ -143,7 +143,6 @@ module('Unit | Service | apollo', function(hooks) {
 
     // Things initialize as empty
     assert.equal(result.get('lastEvent'), null);
-    assert.equal(result.get('events.length'), 0);
 
     // Two updates come in
     nextFunction({ data: { human: { name: '1 Link' }, __typename: 'person' } });
@@ -151,13 +150,6 @@ module('Unit | Service | apollo', function(hooks) {
 
     // Events are in the correct order
     assert.equal(result.get('lastEvent.name'), '2 Luke');
-    assert.equal(
-      result
-        .get('events')
-        .mapBy('name')
-        .join(' '),
-      '2 Luke 1 Link'
-    );
     // Event streams are in the correct order
     assert.equal(names.join(' '), '1 Link 2 Luke');
 
@@ -167,5 +159,6 @@ module('Unit | Service | apollo', function(hooks) {
     nextFunction({ loading: true, data: null });
     // Still have last event
     assert.equal(result.get('lastEvent.name'), '3 Greg');
+    assert.equal(names.join(' '), '1 Link 2 Luke 3 Greg');
   });
 });

--- a/tests/unit/services/apollo-test.js
+++ b/tests/unit/services/apollo-test.js
@@ -4,6 +4,7 @@ import { computed } from '@ember/object';
 import ApolloService from 'ember-apollo-client/services/apollo';
 import testQuery from '../build/test-query';
 import testMutation from '../build/test-mutation';
+import testSubscription from '../build/test-subscription';
 import { Promise } from 'rsvp';
 
 module('Unit | Service | apollo', function(hooks) {
@@ -112,5 +113,59 @@ module('Unit | Service | apollo', function(hooks) {
 
     const result = await service.watchQuery({ query: testQuery }, 'human');
     assert.equal(result.get('name'), undefined);
+  });
+
+  test('.subscribe with key', async function(assert) {
+    let service = this.owner.lookup('service:apollo');
+    let nextFunction = null;
+
+    service.set('client', {
+      subscribe() {
+        assert.ok(true, 'Called subscribe function on apollo client');
+
+        return {
+          subscribe({ next }) {
+            nextFunction = next;
+          },
+        };
+      },
+    });
+
+    const result = await service.subscribe(
+      {
+        subscription: testSubscription,
+      },
+      'human'
+    );
+
+    const names = [];
+    result.on('event', e => names.push(e.name));
+
+    // Things initialize as empty
+    assert.equal(result.get('lastEvent'), null);
+    assert.equal(result.get('events.length'), 0);
+
+    // Two updates come in
+    nextFunction({ data: { human: { name: '1 Link' }, __typename: 'person' } });
+    nextFunction({ data: { human: { name: '2 Luke' }, __typename: 'person' } });
+
+    // Events are in the correct order
+    assert.equal(result.get('lastEvent.name'), '2 Luke');
+    assert.equal(
+      result
+        .get('events')
+        .mapBy('name')
+        .join(' '),
+      '2 Luke 1 Link'
+    );
+    // Event streams are in the correct order
+    assert.equal(names.join(' '), '1 Link 2 Luke');
+
+    nextFunction({ data: { human: { name: '3 Greg' }, __typename: 'person' } });
+    // Stream null
+    nextFunction({ loading: true });
+    nextFunction({ loading: true, data: null });
+    // Still have last event
+    assert.equal(result.get('lastEvent.name'), '3 Greg');
   });
 });


### PR DESCRIPTION
https://github.com/bgentry/ember-apollo-client/issues/4

- [x] Remove `init` chain
- [x] Add subscription support
- [x] Update readme
- [x] Add tests

Allow clients to submit subscription requests and get, in response, a `EmberApolloSubscription` which the client can use in a few ways:
- `subscription.on('event', data => do_something(data))` <-- act on this event in some way
- `subscription.lastEvent` <-- this will be the most recently received event payload
