### PR TITLE
Move graphql to peerDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+
+- `graphql` has been added as a peer dependency and removed from the addon's direct dependency. Please run `ember install ember-apollo-client` to add the default dependencies to your project or run `yarn add -D graphql`.
+
+
 ## [v2.0.0-beta.3] - 2019-03-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This addon is battle tested: it has been used to build several large apps. As su
 ember install ember-apollo-client
 ```
 
-This should also automatically install `ember-fetch`.
+This should also automatically install `ember-fetch` and `graphql`.
 
 Install the [Apollo Client Developer tools for Chrome](https://chrome.google.com/webstore/detail/apollo-client-developer-t/jdkknkkbebbapilgoeccciglkfbmbnfm) for a great GraphQL developer experience!
 

--- a/blueprints/ember-apollo-client/index.js
+++ b/blueprints/ember-apollo-client/index.js
@@ -10,7 +10,8 @@ module.exports = {
    */
   afterInstall() {
     return this.addPackagesToProject([
-      { name: 'ember-fetch', target: '^5.1.1' },
+      { name: 'ember-fetch', target: '^6.3.1' },
+      { name: 'graphql', target: '^14.0.2' },
     ]);
   },
 };

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "2.0.0-beta.3",
   "description": "An ember-cli addon for the Apollo GraphQL Client.",
   "keywords": [
-    "ember-addon",
-    "ember",
-    "apollo-client",
     "apollo",
+    "apollo-client",
+    "ember",
+    "ember-addon",
     "graphql",
     "graphql-client"
   ],
@@ -34,8 +34,7 @@
     "apollo-link-http": "^1.5.9",
     "broccoli-graphql-filter": "^0.3.2",
     "ember-auto-import": "^1.2.19",
-    "ember-cli-babel": "^7.1.2",
-    "graphql": "^14.0.2"
+    "ember-cli-babel": "^7.1.2"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
@@ -66,11 +65,15 @@
     "eslint-plugin-ember": "^6.1.0",
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-prettier": "3.0.1",
+    "graphql": "^14.0.2",
     "graphql-tag": "^2.10.0",
     "graphql-tools": "^4.0.3",
     "loader.js": "^4.7.0",
     "prettier": "^1.15.3",
     "qunit-dom": "^0.8.4"
+  },
+  "peerDependencies": {
+    "graphql": "^14.0.2"
   },
   "engines": {
     "node": "6.* || 8.* || >= 10.*"


### PR DESCRIPTION
This was cherry-picked from #175.
This also closes #124.

I believe this is a breaking change as we are removing it from the "dependencies" and would require people to include `graphql` to their package.json.